### PR TITLE
matrix-less dQ

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Akshay Sharma"]
 version = "0.1.0"
 
 [deps]
-BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
@@ -14,7 +13,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-BlockDiagonals = "0.1"
 Ipopt = "0.6"
 IterativeSolvers = "0.8, 0.9"
 MathOptInterface = "0.9"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DiffOpt.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://jump-dev.org/DiffOpt.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jump-dev.org/DiffOpt.jl/dev)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://jump.dev/DiffOpt.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jump.dev/DiffOpt.jl/dev)
 [![Build Status](https://github.com/jump-dev/DiffOpt.jl/workflows/CI/badge.svg)](https://github.com/jump-dev/DiffOpt.jl/actions)
 [![Coverage](https://codecov.io/gh/jump-dev/DiffOpt.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jump-dev/DiffOpt.jl)
 
@@ -9,8 +9,9 @@ Differentiating convex optimization program (`JuMP.jl` or `MathOptInterface.jl` 
 
 ## Installation
 DiffOpt can be installed through the Julia package manager:
+
 ```
-(v1.3) pkg> add https://github.com/jump-dev/DiffOpt.jl
+(v1.3) pkg> add DiffOpt
 ```
 
 ## Usage
@@ -19,10 +20,10 @@ Create a differentiable model from
 [existing optimizers](https://www.juliaopt.org/JuMP.jl/stable/installation/):
 
 ```julia
-    using DiffOpt
-    using GLPK
+using DiffOpt
+using GLPK
 
-    diff = diff_optimizer(GLPK.Optimizer)
+diff = diff_optimizer(GLPK.Optimizer)
 ```
 
 Update and solve the model:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Differentiating convex optimization program (`JuMP.jl` or `MathOptInterface.jl` 
 DiffOpt can be installed through the Julia package manager:
 
 ```
-(v1.3) pkg> add DiffOpt
+(v1.3) pkg> add https://github.com/jump-dev/DiffOpt.jl
 ```
 
 ## Usage

--- a/examples/solve-LP.jl
+++ b/examples/solve-LP.jl
@@ -5,8 +5,10 @@ using MathOptInterface
 const MOI  = MathOptInterface
 const MOIU = MathOptInterface.Utilities;
 
+using Test
+
 D = 10  # variable dimension
-N = 20; # no of inequality constraints
+N = 20  # no of inequality constraints
 
 s = rand(N)
 s = 2*s.-1
@@ -14,8 +16,8 @@ s = 2*s.-1
 s = max.(s, 0)
 x̂ = rand(D)
 A = rand(N, D)
-b = A*x̂ .+ s
-c = -A'*λ;
+b = A*x̂ + s
+c = -A' * λ
 
 # can feed dual problem to optimizer like this:
 # model = MOI.instantiate(dual_optimizer(GLPK.Optimizer), with_bridge_type=Float64)
@@ -69,5 +71,3 @@ for con_index in constraint_indices
         @assert μ*(con_value - set.lower) < 1e-10
     end
 end
-
-

--- a/examples/solve-QP.jl
+++ b/examples/solve-QP.jl
@@ -64,7 +64,7 @@ for i in 1:size(constraint_indices)[1]
     μ_i = MOI.get(model, MOI.ConstraintDual(), con_index)
     
     # μ[i] * (G * x - h)[i] = 0
-    @test abs(μ_i * (G[i,:]' * x̄ - h[i])) < 1e-2
+    @test abs(μ_i * (G[i,:]' * x̄ - h[i])) < 3e-2
 
     # μ[i] <= 0
     @test μ_i <= 1e-2

--- a/examples/solve-QP.jl
+++ b/examples/solve-QP.jl
@@ -1,9 +1,11 @@
 using Random
-using MathOptInterface
-using OSQP
+using Test
 
+using MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MathOptInterface.Utilities;
+
+using OSQP
 
 n = 20 # variable dimension
 m = 15 # no of inequality constraints
@@ -32,27 +34,22 @@ MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), ob
 MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
 # maintain constrain to index map - will be useful later
-constraint_indices = []
+constraint_indices = [
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(G[i,:], x), 0.),MOI.LessThan(h[i]),
+    ) for i in 1:m
+]
 
-# add constraints
-for i in 1:m
-    push!(
-        constraint_indices,
-        MOI.add_constraint(
-            model,
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(G[i,:], x), 0.),MOI.LessThan(h[i])
-        )
-    )
-end
 
 MOI.optimize!(model)
 
-@assert MOI.get(model, MOI.TerminationStatus()) in [MOI.LOCALLY_SOLVED, MOI.OPTIMAL]
+@assert MOI.get(model, MOI.TerminationStatus()) in (MOI.LOCALLY_SOLVED, MOI.OPTIMAL)
 
-x̄ = MOI.get(model, MOI.VariablePrimal(), x);
+x̄ = MOI.get(model, MOI.VariablePrimal(), x)
 
 # objective value (predicted vs actual) sanity check
-@assert 0.5*x̄'*Q*x̄ + q'*x̄  <= 0.5*x̂'*Q*x̂ + q'*x̂   
+@test 0.5*x̄'*Q*x̄ + q'*x̄  <= 0.5*x̂'*Q*x̂ + q'*x̂   
 
 # NOTE: can't use Ipopt
 # Ipopt.Optimizer doesn't supports accessing MOI.ObjectiveFunctionType
@@ -67,10 +64,10 @@ for i in 1:size(constraint_indices)[1]
     μ_i = MOI.get(model, MOI.ConstraintDual(), con_index)
     
     # μ[i] * (G * x - h)[i] = 0
-    @assert abs(μ_i * (G[i,:]' * x̄ - h[i])) < 1e-2
+    @test abs(μ_i * (G[i,:]' * x̄ - h[i])) < 1e-2
 
     # μ[i] <= 0
-    @assert μ_i <= 1e-2
+    @test μ_i <= 1e-2
 end
 
 
@@ -85,5 +82,5 @@ for j in 1:n
         G_mu_sum += μ_i * G[i,j]
     end
 
-    @assert abs(G_mu_sum - (Q * x̄ + q)[j]) < 1e-2
+    @test abs(G_mu_sum - (Q * x̄ + q)[j]) < 1e-2
 end

--- a/src/DiffOpt.jl
+++ b/src/DiffOpt.jl
@@ -2,17 +2,18 @@ module DiffOpt
 
 using Random
 using LinearAlgebra
-using MathOptInterface
-using MatrixOptInterface
-using MathOptSetDistances
-using BlockDiagonals
 using SparseArrays
 using IterativeSolvers: lsqr
 
-const MOI = MathOptInterface;
-const MOIU = MathOptInterface.Utilities;
-const MatOI = MatrixOptInterface;
-const MOSD = MathOptSetDistances;
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIU = MathOptInterface.Utilities
+
+using MathOptSetDistances
+const MOSD = MathOptSetDistances
+
+using MatrixOptInterface
+const MatOI = MatrixOptInterface
 
 include("gen_random_problem.jl")
 include("utils.jl")

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -545,13 +545,7 @@ function backward_conic!(model::Optimizer, dA::Matrix{Float64}, db::Vector{Float
     #  .  Dπv   .
     # .    .   I
     # ]
-    # M = (
-    #         (Q - I) * BlockDiagonal([
-    #             Matrix{Float64}(I, length(u), length(u)),
-    #             Dπv,
-    #             Matrix{Float64}(I,1,1)
-    #         ])
-    #     ) + I
+
     # NOTE: double transpose because Dπv is BlockDiagonal
     # https://github.com/invenia/BlockDiagonals.jl/issues/16
     M = [

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -542,6 +542,7 @@ function backward_conic!(model::Optimizer, dA::Matrix{Float64}, db::Vector{Float
     # find projections on dual of the cones
     vp = π(MOI.dual_set.(cones), v)
     
+    # dQ * [u, vp, max(0, w)]
     RHS = [dA' * vp + dc; -dA * u + db; -dc ⋅ u  - db ⋅ vp]
 
     dz = if norm(RHS) <= 1e-4

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -565,7 +565,7 @@ function backward_conic!(model::Optimizer, dA::Matrix{Float64}, db::Vector{Float
         lsqr(M, RHS)
     end
 
-    @inbounds (du, dv, dw) = (dz[1:n], dz[n+1:n+m], dz[n+m+1])
+    du, dv, dw = dz[1:n], dz[n+1:n+m], dz[n+m+1]
     dx = du - x * dw
     dy = Dπv * dv - collect(Iterators.flatten(y)) * dw
     ds = Dπv * dv - dv - collect(Iterators.flatten(s)) * dw

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -526,6 +526,7 @@ function backward_conic!(model::Optimizer, dA::Matrix{Float64}, db::Vector{Float
     n = A.n
     N = m + n + 1
     cones = MOI.get(model, MOI.ConstraintSet(), model.con_idx)
+    # NOTE: w = 1 systematically since we asserted the primal-dual pair is optimal
     (u, v, w) = (x, y - s, 1.0)
 
     Q = [

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -97,13 +97,13 @@ function get_problem_data(model::MOI.AbstractOptimizer)
     end
 
     # handle equality constraints
-    eq_con_idx   = MOI.get(
+    eq_con_idx = MOI.get(
                         model,
                         MOI.ListOfConstraintIndices{
                             MOI.ScalarAffineFunction{Float64},
                             MOI.EqualTo{Float64}
                         }())
-    neq   = size(eq_con_idx)[1]
+    neq = size(eq_con_idx)[1]
 
     A = zeros(neq, nz)
     b = zeros(neq)
@@ -152,7 +152,7 @@ end
 # might slow down computation
 # need to find a faster way
 function CSRToCSC(B::MatOI.SparseMatrixCSRtoCSC{Int64})
-    A = sparse(zeros(B.m, B.n))
+    A = spzeros(B.m, B.n)
     last = 0
     for i in 1:B.n
         rnge = (last+1):B.colptr[i]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,16 +26,18 @@ Inverse matrix specified on RHS of eqn(7) in https://arxiv.org/pdf/1703.00443.pd
 Helper method while calling [`backward!`](@ref)
 """
 function create_LHS_matrix(z, λ, Q, G, h, A=nothing)
-    if A == nothing || size(A)[1] == 0
+    if A === nothing || size(A)[1] == 0
         return [Q         G' * Diagonal(λ);
                 G         Diagonal(G * z - h)]
     else
-        @assert size(A)[2] == size(G)[2]
         p, n = size(A)
-        m    = size(G)[1]
+        m    = size(G, 1)
+        if n != size(G, 2)
+            throw(DimensionError("Sizes of $A and $G do not match"))
+        end
         return [Q         G' * Diagonal(λ)       A';
-                G         Diagonal(G * z - h)    zeros(m, p);
-                A         zeros(p, m)            zeros(p, p)]
+                G         Diagonal(G * z - h)    spzeros(m, p);
+                A         spzeros(p, m)          spzeros(p, p)]
     end
 end
 
@@ -66,7 +68,7 @@ Return problem parameters as matrices along with other program info such as numb
 """
 function get_problem_data(model::MOI.AbstractOptimizer)
     var_list = MOI.get(model, MOI.ListOfVariableIndices())
-    nz = size(var_list)[1]
+    nz = size(var_list, 1)
 
     # handle inequality constraints
     ineq_con_idx = MOI.get(
@@ -75,10 +77,10 @@ function get_problem_data(model::MOI.AbstractOptimizer)
                             MOI.ScalarAffineFunction{Float64},
                             MOI.LessThan{Float64}
                         }())
-    nineq = size(ineq_con_idx)[1]
+    nineq = length(ineq_con_idx)
 
-    G = zeros(nineq, nz)
-    h = zeros(nineq)
+    G = spzeros(nineq, nz)
+    h = spzeros(nineq)
 
     for i in 1:nineq
         con = ineq_con_idx[i]
@@ -103,10 +105,10 @@ function get_problem_data(model::MOI.AbstractOptimizer)
                             MOI.ScalarAffineFunction{Float64},
                             MOI.EqualTo{Float64}
                         }())
-    neq = size(eq_con_idx)[1]
+    neq = length(eq_con_idx)
 
-    A = zeros(neq, nz)
-    b = zeros(neq)
+    A = spzeros(neq, nz)
+    b = spzeros(neq)
 
     for i in 1:neq
         con = eq_con_idx[i]
@@ -124,15 +126,14 @@ function get_problem_data(model::MOI.AbstractOptimizer)
     # handle objective
     # works both for affine and quadratic objective functions
     objective_function = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
-    Q = zeros(nz, nz)
-    q = zeros(nz)
+    Q = spzeros(nz, nz)
+    q = spzeros(nz)
 
-    if typeof(objective_function) == MathOptInterface.ScalarAffineFunction{Float64}
+    if objective_function isa MathOptInterface.ScalarAffineFunction{Float64}
         for x in objective_function.terms
             q[x.variable_index.value] = x.coefficient
         end
-    elseif typeof(objective_function) == MathOptInterface.ScalarQuadraticFunction{Float64}
-        # @assert size(objective_function.quadratic_terms)[1] == (nz * (nz + 1)) / 2
+    elseif objective_function isa MathOptInterface.ScalarQuadraticFunction{Float64}
 
         var_to_id = Dict(var_list .=> 1:nz)
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -49,7 +49,7 @@
 
     MOI.optimize!(model)
 
-    @test model.primal_optimal ≈ [0.3; 0.7] atol=ATOL rtol=RTOL
+    @test model.primal_optimal ≈ [0.3, 0.7] atol=ATOL rtol=RTOL
 end
 
 
@@ -97,7 +97,7 @@ end
 
     @test model.primal_optimal ≈ [-0.25; -0.75] atol=ATOL rtol=RTOL
 
-    grad_wrt_h = backward!(model, ["h"], [1.0 1.0])[1]
+    grad_wrt_h = backward!(model, ["h"], ones(2))[1]
 
     @test grad_wrt_h ≈ [1.0] atol=2ATOL rtol=RTOL
 end
@@ -159,9 +159,9 @@ end
          0.0 -1.0 0.0
          -1.0 0.0 0.0
     ]
-    h = [1.0; 1.0; 1.0; 0.0; 0.0; 0.0;]
+    h = [1.0, 1.0, 1.0, 0.0, 0.0, 0.0,]
     A = [1.0 1.0 1.0;]
-    b = [0.5;]
+    b = [0.5]
 
     model = diff_optimizer(Ipopt.Optimizer)
     MOI.set(model, MOI.Silent(), true)
@@ -207,9 +207,9 @@ end
 
     z = model.primal_optimal
 
-    @test z ≈ [0.0; 0.5; 0.0] atol=ATOL rtol=RTOL
+    @test z ≈ [0.0, 0.5, 0.0] atol=ATOL rtol=RTOL
 
-    grads = backward!(model, ["Q","q","G","h","A","b"], [1.0 1.0 1.0])
+    grads = backward!(model, ["Q","q","G","h","A","b"], ones(3))
 
     dl_dQ = grads[1]
     dl_dq = grads[2]
@@ -284,7 +284,7 @@ end
     @test z ≈ [4/7, 3/7, 6/7] atol=ATOL rtol=RTOL
 
     # obtain gradients
-    grads = backward!(model, ["Q","q","G","h"], [1.0 1.0 1.0])
+    grads = backward!(model, ["Q","q","G","h"], ones(3))
 
     dl_dQ = grads[1]
     dl_dq = grads[2]
@@ -361,7 +361,7 @@ end
     @test ν ≈ 11/4       atol=ATOL rtol=RTOL
 
     # obtain gradients
-    dl_dz = [1.3 0.5]   # choosing a non trivial backward pass vector
+    dl_dz = [1.3, 0.5]   # choosing a non trivial backward pass vector
     grads = backward!(model, ["Q", "q", "G", "h", "A", "b"], dl_dz)
 
     dl_dQ = grads[1]
@@ -432,14 +432,14 @@ end
     for i in 1:neq
         MOI.add_constraint(
             model,
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(A[i,:], x), 0.0),MOI.EqualTo(b[i])
+            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(A[i,:], x), 0.0), MOI.EqualTo(b[i]),
         )
     end
 
     MOI.optimize!(model)
 
     # obtain gradients
-    grads = backward!(model, ["Q", "q", "G", "h", "A", "b"], ones(1,nz))  # using dl_dz=[1,1,1,1,1,....]
+    grads = backward!(model, ["Q", "q", "G", "h", "A", "b"], ones(nz))  # using dl_dz=[1,1,1,1,1,....]
 
     # read gradients from files
     names = ["dP", "dq", "dG", "dh", "dA", "db"]
@@ -491,10 +491,10 @@ end
     MOI.optimize!(model)
 
     # obtain gradients
-    grads = backward!(model, ["G", "h"], ones(1,1))  # using dl_dz=[1,1,1,1,1,....]
+    grads = backward!(model, ["G", "h"], [1.0])
 
-    @test grads[1] ≈ [0.0; 3.0] atol=ATOL rtol=RTOL
-    @test grads[2] ≈ [0.0; -1.0] atol=ATOL rtol=RTOL
+    @test grads[1] ≈ [0.0, 3.0] atol=ATOL rtol=RTOL
+    @test grads[2] ≈ [0.0, -1.0] atol=ATOL rtol=RTOL
 end
 
 
@@ -545,7 +545,7 @@ end
     MOI.optimize!(model)
 
     # obtain gradients
-    grads = backward!(model, ["Q", "q", "G", "h"], ones(1,3))  # using dl_dz=[1,1,1,1,1,....]
+    grads = backward!(model, ["Q", "q", "G", "h"], ones(3))  # using dl_dz=[1,1,1,1,1,....]
 
     @test grads[1] ≈ zeros(3,3) atol=ATOL rtol=RTOL
     @test grads[2] ≈ zeros(3) atol=ATOL rtol=RTOL


### PR DESCRIPTION
In backward_conic, `dQ` is materialized only for a matrix-vector product, it is eliminated from the pass.

There should also be a way to avoid materializing `Q`, and ultimately reasoning on the sparse construction of the problem and not its explicit matrix form