### PR TITLE
Replace CSRtoCSC by convert

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -145,16 +145,3 @@ function get_problem_data(model::MOI.AbstractOptimizer)
 
     return Q, q, G, h, A, b, nz, var_list, nineq, ineq_con_idx, neq, eq_con_idx
 end
-
-# might slow down computation
-# need to find a faster way
-function CSRToCSC(B::MatOI.SparseMatrixCSRtoCSC{T, Int}) where {T}
-    A = spzeros(T, B.m, B.n)
-    last = 0
-    for i in 1:B.n
-        rnge = (last+1):B.colptr[i]
-        A[(1 .+ B.rowval[rnge]), i] = B.nzval[rnge]
-        last = B.colptr[i]
-    end
-    return A
-end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -583,7 +583,7 @@ end
     x = model.primal_optimal
 
     cone_types = unique([S for (F, S) in MOI.get(model.optimizer, MOI.ListOfConstraints())])
-    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int}, Vector{Float64}}(cone_types)
+    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int, MatOI.OneBasedIndexing}, Vector{Float64}}(cone_types)
     index_map = MOI.copy_to(conic_form, model)
 
     s = DiffOpt.map_rows((ci, r) -> MOI.get(model.optimizer, MOI.ConstraintPrimal(), ci), model.optimizer, conic_form, index_map, DiffOpt.Flattened{Float64}())
@@ -647,7 +647,7 @@ function simple_psd(solver)
     x = model.primal_optimal
 
     cone_types = unique([S for (F, S) in MOI.get(model.optimizer, MOI.ListOfConstraints())])
-    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int}, Vector{Float64}}(cone_types)
+    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int, MatOI.OneBasedIndexing}, Vector{Float64}}(cone_types)
     index_map = MOI.copy_to(conic_form, model)
 
     s = DiffOpt.map_rows((ci, r) -> MOI.get(model.optimizer, MOI.ConstraintPrimal(), ci), model.optimizer, conic_form, index_map, DiffOpt.Flattened{Float64}())
@@ -773,7 +773,7 @@ end
     x = model.primal_optimal
 
     cone_types = unique([S for (F, S) in MOI.get(model.optimizer, MOI.ListOfConstraints())])
-    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int}, Vector{Float64}}(cone_types)
+    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int, MatOI.OneBasedIndexing}, Vector{Float64}}(cone_types)
     index_map = MOI.copy_to(conic_form, model)
 
     s = DiffOpt.map_rows((ci, r) -> MOI.get(model.optimizer, MOI.ConstraintPrimal(), ci), model.optimizer, conic_form, index_map, DiffOpt.Flattened{Float64}())
@@ -854,7 +854,7 @@ end
     x = model.primal_optimal
 
     cone_types = unique([S for (F, S) in MOI.get(model.optimizer, MOI.ListOfConstraints())])
-    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int}, Vector{Float64}}(cone_types)
+    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int, MatOI.OneBasedIndexing}, Vector{Float64}}(cone_types)
     index_map = MOI.copy_to(conic_form, model)
 
     s = DiffOpt.map_rows((ci, r) -> MOI.get(model.optimizer, MOI.ConstraintPrimal(), ci), model.optimizer, conic_form, index_map, DiffOpt.Flattened{Float64}())
@@ -926,7 +926,7 @@ end
     x = model.primal_optimal
 
     cone_types = unique([S for (F, S) in MOI.get(model.optimizer, MOI.ListOfConstraints())])
-    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int}, Vector{Float64}}(cone_types)
+    conic_form = MatOI.GeometricConicForm{Float64, MatOI.SparseMatrixCSRtoCSC{Float64, Int, MatOI.OneBasedIndexing}, Vector{Float64}}(cone_types)
     index_map = MOI.copy_to(conic_form, model)
 
     s = DiffOpt.map_rows((ci, r) -> MOI.get(model.optimizer, MOI.ConstraintPrimal(), ci), model.optimizer, conic_form, index_map, DiffOpt.Flattened{Float64}())


### PR DESCRIPTION
https://github.com/jump-dev/MatrixOptInterface.jl/pull/22 just broke DiffOpt. This PR fixes this and also use the `convert` function added in https://github.com/jump-dev/MatrixOptInterface.jl/pull/21.