### PR TITLE
ForwardIn{...Objective} -> ForwardInObjective

### DIFF
--- a/docs/src/sensitivity-analysis-svm.md
+++ b/docs/src/sensitivity-analysis-svm.md
@@ -172,10 +172,9 @@ for Xi in 1:N
     
     MOI.set(
         model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), 
-        b, 
+        DiffOpt.ForwardInConstraint(), 
         cons, 
-        dy
+        MOIU.vectorize(dy .* b),
     )
     
     DiffOpt.forward(model)
@@ -228,10 +227,9 @@ for Xi in 1:N
     for i in 1:D
         MOI.set(
             model,
-            DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), 
-            w[i], 
+            DiffOpt.ForwardInConstraint(), 
             cons, 
-            dX[:,i]
+            MOIU.vectorize(dX[:,i] .* w[i]),
         )
     end
     

--- a/docs/src/sensitivity-analysis-svm.md
+++ b/docs/src/sensitivity-analysis-svm.md
@@ -174,7 +174,7 @@ for Xi in 1:N
         model,
         DiffOpt.ForwardInConstraint(),
         cons,
-        MOIU.vectorize(dy .* b),
+        MOI.Utilities.vectorize(dy .* b),
     )
 
     DiffOpt.forward(model)
@@ -229,7 +229,7 @@ for Xi in 1:N
             model,
             DiffOpt.ForwardInConstraint(),
             cons,
-            MOIU.vectorize(dX[:,i] .* w[i]),
+            MOI.Utilities.vectorize(dX[:,i] .* w[i]),
         )
     end
 

--- a/docs/src/sensitivity-analysis-svm.md
+++ b/docs/src/sensitivity-analysis-svm.md
@@ -45,7 +45,7 @@ nothing # hide
 
 Let's define the variables.
 ```@example 1
-model = diff_optimizer(SCS.Optimizer) 
+model = diff_optimizer(SCS.Optimizer)
 MOI.set(model, MOI.Silent(), true)
 
 # add variables
@@ -61,7 +61,7 @@ MOI.add_constraint(
     model,
     MOI.VectorAffineFunction(
         MOI.VectorAffineTerm.(1:N, MOI.ScalarAffineTerm.(1.0, l)), zeros(N),
-    ), 
+    ),
     MOI.Nonnegatives(N),
 )
 
@@ -101,7 +101,7 @@ bv = MOI.get(model, MOI.VariablePrimal(), b)
 nothing # hide
 ```
 
-We can visualize the separating hyperplane. 
+We can visualize the separating hyperplane.
 
 ```@example 1
 # build SVM points
@@ -139,16 +139,16 @@ where
 \begin{align*}
 c &= [l_1 - 1, l_2 -1, ... l_N -1, 0, 0, ... 0 \text{(D+1 times)}] \\\\
 
-A &= 
+A &=
 \begin{bmatrix}
- -l_1 &    0 & ... &    0 &            0 & ... & 0 & 0  \\ 
-    0 & -l_2 & ... &    0 &            0 & ... & 0 & 0  \\ 
-    : &    : & ... &    : &            0 & ... & 0 & 0  \\ 
-    0 &    0 & ... & -l_N &            0 & ... & 0 & 0  \\ 
-    0 &    0 & ... &    0 & -y_1 X_{1,1} & ... & -y_1 X_{1,N} & -y_1  \\ 
-    0 &    0 & ... &    0 & -y_2 X_{2,1} & ... & -y_1 X_{2,N} & -y_2  \\ 
-    : &    : & ... &    : &           :  & ... &          :   & :   \\ 
-    0 &    0 & ... &    0 & -y_N X_{N,1} & ... & -y_N X_{N,N} & -y_N  \\ 
+ -l_1 &    0 & ... &    0 &            0 & ... & 0 & 0  \\
+    0 & -l_2 & ... &    0 &            0 & ... & 0 & 0  \\
+    : &    : & ... &    : &            0 & ... & 0 & 0  \\
+    0 &    0 & ... & -l_N &            0 & ... & 0 & 0  \\
+    0 &    0 & ... &    0 & -y_1 X_{1,1} & ... & -y_1 X_{1,N} & -y_1  \\
+    0 &    0 & ... &    0 & -y_2 X_{2,1} & ... & -y_1 X_{2,N} & -y_2  \\
+    : &    : & ... &    : &           :  & ... &          :   & :   \\
+    0 &    0 & ... &    0 & -y_N X_{N,1} & ... & -y_N X_{N,N} & -y_N  \\
 \end{bmatrix} \\\\
 
 b &= [0, 0, ... 0 \text{(N times)}, l_1 - 1, l_2 -1, ... l_N -1] \\\\
@@ -169,28 +169,28 @@ dy = zeros(N)
 # begin differentiating
 for Xi in 1:N
     dy[Xi] = 1.0  # set
-    
+
     MOI.set(
         model,
-        DiffOpt.ForwardInConstraint(), 
-        cons, 
+        DiffOpt.ForwardInConstraint(),
+        cons,
         MOIU.vectorize(dy .* b),
     )
-    
+
     DiffOpt.forward(model)
-    
+
     dw = MOI.get.(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOutVariablePrimal(),
         w
-    ) 
+    )
     db = MOI.get(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOutVariablePrimal(),
         b
-    ) 
+    )
     push!(∇, norm(dw) + norm(db))
-    
+
     dy[Xi] = 0.0  # reset the change made above
 end
 LinearAlgebra.normalize!(∇)
@@ -200,7 +200,7 @@ nothing # hide
 Visualize point sensitivities with respect to separating hyperplane. Note that the gradients are normalized.
 ```@example 1
 p2 = Plots.scatter(
-    X[:,1], X[:,2], 
+    X[:,1], X[:,2],
     color = [yi > 0 ? :red : :blue for yi in y], label = "",
     markersize = ∇ * 20,
 )
@@ -223,30 +223,30 @@ dX = zeros(N, D)
 # begin differentiating
 for Xi in 1:N
     dX[Xi, :] = ones(D)  # set
-    
+
     for i in 1:D
         MOI.set(
             model,
-            DiffOpt.ForwardInConstraint(), 
-            cons, 
+            DiffOpt.ForwardInConstraint(),
+            cons,
             MOIU.vectorize(dX[:,i] .* w[i]),
         )
     end
-    
+
     DiffOpt.forward(model)
-    
+
     dw = MOI.get.(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOutVariablePrimal(),
         w
-    ) 
+    )
     db = MOI.get(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOutVariablePrimal(),
         b
-    ) 
+    )
     push!(∇, norm(dw) + norm(db))
-    
+
     dX[Xi, :] = zeros(D)  # reset the change made ago
 end
 LinearAlgebra.normalize!(∇)
@@ -255,7 +255,7 @@ LinearAlgebra.normalize!(∇)
 We can visualize point sensitivity with respect to the separating hyperplane. Note that the gradients are normalized.
 ```@example 1
 p3 = Plots.scatter(
-    X[:,1], X[:,2], 
+    X[:,1], X[:,2],
     color = [yi > 0 ? :red : :blue for yi in y], label = "",
     markersize = ∇ * 20,
 )

--- a/docs/src/sensitivity-analysis-svm.md
+++ b/docs/src/sensitivity-analysis-svm.md
@@ -174,7 +174,7 @@ for Xi in 1:N
         model,
         DiffOpt.ForwardInConstraint(),
         cons,
-        MOI.Utilities.vectorize(dy .* b),
+        MOI.Utilities.vectorize(dy .* MOI.SingleVariable(b)),
     )
 
     DiffOpt.forward(model)

--- a/docs/src/solve-conic-1.md
+++ b/docs/src/solve-conic-1.md
@@ -190,28 +190,15 @@ println("s -> ", round.(s_sol; digits=3))
 println("y -> ", round.(y_sol; digits=3))
 
 # perturbations in all the parameters
-for xi in vcat(X, x)
-    MOI.set(model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), xi, cX, ones(6))
-    MOI.set(model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), xi, cx, ones(3))
-    MOI.set(model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), xi, c1, ones(1))
-    MOI.set(model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), xi, c2, ones(1))
-end
+fx = MOI.SingleVariable.(x)
 MOI.set(model,
-    DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), cX, ones(6))
+    DiffOpt.ForwardInConstraint(), c1, MOIU.vectorize(ones(1, 9) * fx + ones(1)))
 MOI.set(model,
-    DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), cx, ones(3))
+    DiffOpt.ForwardInConstraint(), c2, MOIU.vectorize(ones(6, 9) * fx + ones(6)))
 MOI.set(model,
-    DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c1, ones(1))
+    DiffOpt.ForwardInConstraint(), c3, MOIU.vectorize(ones(3, 9) * fx + ones(3)))
 MOI.set(model,
-    DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c2, ones(1))
-for xi in vcat(X, x)
-    MOI.set(model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), xi, 1.0)
-end
+    DiffOpt.ForwardInConstraint(), c4, MOIU.vectorize(ones(1, 9) * fx + ones(1)))
 
 # differentiate and get the gradients
 DiffOpt.forward(model)

--- a/docs/src/solve-conic-1.md
+++ b/docs/src/solve-conic-1.md
@@ -192,13 +192,13 @@ println("y -> ", round.(y_sol; digits=3))
 # perturbations in all the parameters
 fx = MOI.SingleVariable.(x)
 MOI.set(model,
-    DiffOpt.ForwardInConstraint(), c1, MOIU.vectorize(ones(1, 9) * fx + ones(1)))
+    DiffOpt.ForwardInConstraint(), c1, MOI.Utilities.vectorize(ones(1, 9) * fx + ones(1)))
 MOI.set(model,
-    DiffOpt.ForwardInConstraint(), c2, MOIU.vectorize(ones(6, 9) * fx + ones(6)))
+    DiffOpt.ForwardInConstraint(), c2, MOI.Utilities.vectorize(ones(6, 9) * fx + ones(6)))
 MOI.set(model,
-    DiffOpt.ForwardInConstraint(), c3, MOIU.vectorize(ones(3, 9) * fx + ones(3)))
+    DiffOpt.ForwardInConstraint(), c3, MOI.Utilities.vectorize(ones(3, 9) * fx + ones(3)))
 MOI.set(model,
-    DiffOpt.ForwardInConstraint(), c4, MOIU.vectorize(ones(1, 9) * fx + ones(1)))
+    DiffOpt.ForwardInConstraint(), c4, MOI.Utilities.vectorize(ones(1, 9) * fx + ones(1)))
 
 # differentiate and get the gradients
 DiffOpt.forward(model)

--- a/docs/src/solve-conic-1.md
+++ b/docs/src/solve-conic-1.md
@@ -204,7 +204,7 @@ MOI.set(model,
 DiffOpt.forward(model)
 
 dx = MOI.get.(model,
-    DiffOpt.ForwardOut{MOI.VariablePrimal}(), vcat(X, x))
+    DiffOpt.ForwardOutVariablePrimal(), vcat(X, x))
 
 println("dx -> ", round.(dx; digits=3))
 # println("ds -> ", round.(ds; digits=3))

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -53,5 +53,5 @@ we can use the `forward` method with perturbations in matrices `A`, `b`, `c`
 using LinearAlgebra # for `⋅`
 MOI.set(model, DiffOpt.ForwardInObjective(), ones(2) ⋅ MOI.SingleVariable.(x))
 DiffOpt.forward(model)
-grad_x = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), x)
+grad_x = MOI.get.(model, DiffOpt.ForwardOutVariablePrimal(), x)
 ```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -50,8 +50,9 @@ we can use the `backward` method
 
 we can use the `forward` method with perturbations in matrices `A`, `b`, `c`
 ```julia
-    MOI.set.(model,
-        DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), x, ones(2))
-    DiffOpt.forward(model)
-    grad_x = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), x)
+dobj = ones(2)' * MOI.SingleVariable.(x)
+MOI.set.(model,
+    DiffOpt.ForwardInObjective{typeof(dobj)}(), dobj)
+DiffOpt.forward(model)
+grad_x = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), x)
 ```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -31,7 +31,7 @@ Finally differentiate the model (primal and dual variables specifically) to obta
 we can use the `backward` method
 ```julia
     MOI.set.(model,
-        DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+        DiffOpt.BackwardInVariablePrimal(), x, ones(2))
     DiffOpt.backward(model)
     grad_obj = MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.LinearObjective}(), x)
     grad_rhs = MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -50,9 +50,8 @@ we can use the `backward` method
 
 we can use the `forward` method with perturbations in matrices `A`, `b`, `c`
 ```julia
-dobj = ones(2)' * MOI.SingleVariable.(x)
-MOI.set.(model,
-    DiffOpt.ForwardInObjective{typeof(dobj)}(), dobj)
+using LinearAlgebra # for `⋅`
+MOI.set(model, DiffOpt.ForwardInObjective(), ones(2) ⋅ MOI.SingleVariable.(x))
 DiffOpt.forward(model)
 grad_x = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), x)
 ```

--- a/examples/chainrules.jl
+++ b/examples/chainrules.jl
@@ -101,7 +101,7 @@ function ChainRulesCore.frule((_, Δload1_demand, Δload2_demand, Δgen_costs, �
     MOI.set(model, DiffOpt.ForwardInObjective(), Δobj)
     DiffOpt.forward(JuMP.backend(model))
     # querying the corresponding perturbation of the decision
-    Δp = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), p)
+    Δp = MOI.get.(model, DiffOpt.ForwardOutVariablePrimal(), p)
     return (pv, Δp.data)
 end
 

--- a/examples/chainrules.jl
+++ b/examples/chainrules.jl
@@ -40,33 +40,33 @@ function unit_commitment(load1_demand, load2_demand, gen_costs, noload_costs; mo
     # for a linear relaxation.
     @variable(model, 0 <= u[g in unit_codes, t in 1:n_periods] <= 1) # Commitment
     @variable(model, p[g in unit_codes, t in 1:n_periods] >= 0) # Power output (pu)
-    
+
     ## Constraints
-    
+
     # Energy balance
     @constraint(
         model,
         energy_balance_cons[t in 1:n_periods],
         sum(p[g, t] for g in unit_codes) == sum(D[l][t] for l in load_names),
     )
-    
+
     # Generation limits
     @constraint(model, [g in unit_codes, t in 1:n_periods], Pmin[g][t] * u[g, t] <= p[g, t])
     @constraint(model, [g in unit_codes, t in 1:n_periods], p[g, t] <= Pmax[g][t] * u[g, t])
-    
+
     # Ramp rates
     @constraint(model, [g in unit_codes, t in 2:n_periods], p[g, t] - p[g, t - 1] <= 60 * RR[g])
     @constraint(model, [g in unit_codes], p[g, 1] - P0[g] <= 60 * RR[g])
     @constraint(model, [g in unit_codes, t in 2:n_periods], p[g, t - 1] - p[g, t] <= 60 * RR[g])
     @constraint(model, [g in unit_codes], P0[g] - p[g, 1] <= 60 * RR[g])
-    
+
     # Objective
     @objective(
         model,
         Min,
         sum((Cp[g] * p[g, t]) + (Cnl[g] * u[g, t]) for g in unit_codes, t in 1:n_periods),
     )
-    
+
     optimize!(model)
     @assert termination_status(model) == MOI.OPTIMAL
     # converting to dense matrix
@@ -97,12 +97,8 @@ function ChainRulesCore.frule((_, Δload1_demand, Δload2_demand, Δgen_costs, �
     u = model[:u]
 
     # setting the perturbation of the linear objective
-    for t in size(p, 2)
-        MOI.set(model, DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), p[1,t], Δgen_costs[1])
-        MOI.set(model, DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), p[2,t], Δgen_costs[2])
-        MOI.set(model, DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), u[1,t], Δnoload_costs[1])
-        MOI.set(model, DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), u[2,t], Δnoload_costs[2])
-    end
+    dobj = sum(Δgen_costs ⋅ p[:,t] + Δnoload_costs ⋅ u[:,t] for t in size(p, 2))
+    DiffOpt.set_forward_diff_objective(model, dobj)
     DiffOpt.forward(JuMP.backend(model))
     # querying the corresponding perturbation of the decision
     Δp = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), p)
@@ -143,7 +139,7 @@ function ChainRulesCore.rrule(::typeof(unit_commitment), load1_demand, load2_dem
         dnoload_costs = similar(noload_costs)
         dnoload_costs[1] = sum(MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.LinearObjective}(), u[1,:]))
         dnoload_costs[2] = sum(MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.LinearObjective}(), u[2,:]))
-        
+
         # computing derivative wrt constraint constant
         dload1_demand = MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), energy_balance_cons)
         dload2_demand = copy(dload1_demand)

--- a/examples/chainrules.jl
+++ b/examples/chainrules.jl
@@ -97,8 +97,8 @@ function ChainRulesCore.frule((_, Δload1_demand, Δload2_demand, Δgen_costs, �
     u = model[:u]
 
     # setting the perturbation of the linear objective
-    dobj = sum(Δgen_costs ⋅ p[:,t] + Δnoload_costs ⋅ u[:,t] for t in size(p, 2))
-    DiffOpt.set_forward_diff_objective(model, dobj)
+    Δobj = sum(Δgen_costs ⋅ p[:,t] + Δnoload_costs ⋅ u[:,t] for t in size(p, 2))
+    MOI.set(model, DiffOpt.ForwardInObjective(), Δobj)
     DiffOpt.forward(JuMP.backend(model))
     # querying the corresponding perturbation of the decision
     Δp = MOI.get.(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), p)

--- a/examples/chainrules.jl
+++ b/examples/chainrules.jl
@@ -128,7 +128,7 @@ function ChainRulesCore.rrule(::typeof(unit_commitment), load1_demand, load2_dem
         u = model[:u]
         energy_balance_cons = model[:energy_balance_cons]
 
-        MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), p, pb)
+        MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), p, pb)
         DiffOpt.backward(JuMP.backend(model))
 
         # computing derivative wrt linear objective costs

--- a/examples/chainrules.jl
+++ b/examples/chainrules.jl
@@ -89,8 +89,8 @@ function ChainRulesCore.frule((_, Δload1_demand, Δload2_demand, Δgen_costs, �
     # the corresponding perturbation are set accordingly as the set of perturbations of the two loads
     MOI.set.(
         model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), energy_balance_cons,
-        [d1 + d2 for (d1, d2) in zip(Δload1_demand, Δload2_demand)],
+        DiffOpt.ForwardInConstraint(), energy_balance_cons,
+        [convert(MOI.ScalarAffineFunction{Float64}, d1 + d2) for (d1, d2) in zip(Δload1_demand, Δload2_demand)],
     )
 
     p = model[:p]

--- a/examples/sensitivity-SVM.jl
+++ b/examples/sensitivity-SVM.jl
@@ -96,12 +96,12 @@ for Xi in 1:N
 
     dw = MOI.get.(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
+        DiffOpt.ForwardOutVariablePrimal(),
         w
     )
     db = MOI.get(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
+        DiffOpt.ForwardOutVariablePrimal(),
         b
     )
     push!(∇, norm(dw) + norm(db))
@@ -145,12 +145,12 @@ for Xi in 1:N
 
     dw = MOI.get.(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
+        DiffOpt.ForwardOutVariablePrimal(),
         w
     )
     db = MOI.get(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
+        DiffOpt.ForwardOutVariablePrimal(),
         b
     )
     push!(∇, norm(dw) + norm(db))

--- a/examples/sensitivity-SVM.jl
+++ b/examples/sensitivity-SVM.jl
@@ -24,7 +24,7 @@ Random.seed!(rand(1:100))
 X = vcat(randn(N, D), randn(N,D) .+ [4.0,1.5]')
 y = append!(ones(N), -ones(N));
 
-model = diff_optimizer(SCS.Optimizer) 
+model = diff_optimizer(SCS.Optimizer)
 
 # add variables
 l = MOI.add_variables(model, N)
@@ -35,7 +35,7 @@ MOI.add_constraint(
     model,
     MOI.VectorAffineFunction(
         MOI.VectorAffineTerm.(1:N, MOI.ScalarAffineTerm.(1.0, l)), zeros(N)
-    ), 
+    ),
     MOI.Nonnegatives(N),
 )
 
@@ -84,29 +84,28 @@ dy = zeros(N)
 # begin differentiating
 for Xi in 1:N
     dy[Xi] = 1.0  # set
-    
+
     MOI.set(
         model,
-        DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), 
-        b, 
-        cons, 
-        dy
+        DiffOpt.ForwardInConstraint(),
+        cons,
+        MOIU.vectorize(dy .* MOI.SingleVariable(b)),
     )
-    
+
     DiffOpt.forward(model)
-    
+
     dw = MOI.get.(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
         w
-    ) 
+    )
     db = MOI.get(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
         b
-    ) 
+    )
     push!(∇, norm(dw) + norm(db))
-    
+
     dy[Xi] = 0.0  # reset the change made above
 end
 normalize!(∇)
@@ -116,7 +115,7 @@ normalize!(∇)
 
 if should_plot
     p2 = Plots.scatter(
-        X[:,1], X[:,2], 
+        X[:,1], X[:,2],
         color = [yi > 0 ? :red : :blue for yi in y], label = "",
         markersize = ∇ * 20,
     )
@@ -132,31 +131,30 @@ dX = zeros(N, D)
 # begin differentiating
 for Xi in 1:N
     dX[Xi, :] = ones(D)  # set
-    
+
     for i in 1:D
         MOI.set(
             model,
-            DiffOpt.ForwardIn{DiffOpt.ConstraintCoefficient}(), 
-            w[i], 
-            cons, 
-            dX[:,i]
+            DiffOpt.ForwardInConstraint(),
+            cons,
+            MOIU.vectorize(dX[:,i] .* MOI.SingleVariable(w[i])),
         )
     end
-    
+
     DiffOpt.forward(model)
-    
+
     dw = MOI.get.(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
         w
-    ) 
+    )
     db = MOI.get(
         model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), 
+        DiffOpt.ForwardOut{MOI.VariablePrimal}(),
         b
-    ) 
+    )
     push!(∇, norm(dw) + norm(db))
-    
+
     dX[Xi, :] = zeros(D)  # reset the change made ago
 end
 normalize!(∇)
@@ -166,7 +164,7 @@ normalize!(∇)
 
 if should_plot
     p3 = Plots.scatter(
-        X[:,1], X[:,2], 
+        X[:,1], X[:,2],
         color = [yi > 0 ? :red : :blue for yi in y], label = "",
         markersize = ∇ * 20,
     )

--- a/examples/unit_example.jl
+++ b/examples/unit_example.jl
@@ -58,7 +58,7 @@ diff_opt = backend(model).optimizer.model
 v = MOI.get(model, MOI.ListOfVariableIndices())
 nv = length(v)
 
-MOI.set.(diff_opt, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, ones(nv))
+MOI.set.(diff_opt, DiffOpt.BackwardInVariablePrimal(), v, ones(nv))
 
 DiffOpt.backward(diff_opt)
 

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -135,7 +135,7 @@ MOI.set(model, DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), x)
 struct ForwardIn{T} <: AbstractDiffAttribute end
 
 """
-    ForwardInObjective{F<:MOI.AbstractScalarFunction}
+    ForwardInObjective
 
 A `MOI.AbstractModelAttribute` to set input data to forward differentiation, that
 is, problem input data.
@@ -148,12 +148,11 @@ computinig the derivative with respect to `θ`, the following should be set:
 ```julia
 fx = MOI.SingleVariable(x)
 fy = MOI.SingleVariable(y)
-obj = 1.0 * fx + 2.0 * fy
-MOI.set(model, DiffOpt.ForwardInObjective{obj}(), obj)
+MOI.set(model, DiffOpt.ForwardInObjective(), 1.0 * fx + 2.0 * fy)
 ```
 where `x` and `y` are the relevant `MOI.VariableIndex`.
 """
-struct ForwardInObjective{F<:MOI.AbstractScalarFunction} <: MOI.AbstractModelAttribute end
+struct ForwardInObjective <: MOI.AbstractModelAttribute end
 
 """
     ForwardOut{T}
@@ -308,10 +307,10 @@ function _get_dc(b_cache::QPForwBackCache, g_cache::QPCache, vi)
     return dz[i]
 end
 
-function MOI.get(model::Optimizer, ::ForwardInObjective{F})::F where {F}
+function MOI.get(model::Optimizer, ::ForwardInObjective)
     return model.input_cache.objective
 end
-function MOI.set(model::Optimizer, ::ForwardInObjective{F}, objective::F) where {F}
+function MOI.set(model::Optimizer, ::ForwardInObjective, objective)
     model.input_cache.objective = objective
     return
 end

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -160,18 +160,20 @@ struct ForwardInConstraint <: MOI.AbstractConstraintAttribute end
 
 
 """
-    ForwardOut{T}
+    ForwardOutVariablePrimal
 
-A AbstractDiffAttribute to set output data to backward differentiation, that
-is, problem solution.
-The input data includes:
-MOI.VariablePrimal.
+A `MOI.AbstractVariableAttribute` to get output data from forward
+differentiation, that is, problem solution.
 
+For instance, to get the tangent of the variable of index `vi` corresponding to
+the tangents given to `ForwardInObjective` and `ForwardInConstraint`, do the
+following:
 ```julia
-MOI.get(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), x)
+MOI.get(model, DiffOpt.ForwardOutVariablePrimal(), vi)
 ```
 """
-struct ForwardOut{T} <: AbstractDiffAttribute end
+struct ForwardOutVariablePrimal <: MOI.AbstractVariableAttribute end
+MOI.is_set_by_optimize(::ForwardOutVariablePrimal) = true
 
 """
     BackwardIn{T}
@@ -270,7 +272,7 @@ mutable struct Optimizer{OT <: MOI.ModelLike} <: MOI.AbstractOptimizer
     end
 end
 
-function MOI.get(model::Optimizer, ::ForwardOut{MOI.VariablePrimal}, vi::VI)
+function MOI.get(model::Optimizer, ::ForwardOutVariablePrimal, vi::VI)
     return _get_dx(model, vi)
 end
 _get_dx(model::Optimizer, vi) = _get_dx(model.forw_grad_cache, model.gradient_cache, vi)
@@ -546,7 +548,7 @@ This method will consider as input a currently solved problem and
 differentials with respect to problem data set with
 the [`ForwardInObjective`](@ref) and  [`ForwardInConstraint`](@ref) attributes.
 The output solution differentials can be queried with the attribute
-[`ForwardOut`](@ref).
+[`ForwardOutVariablePrimal`](@ref).
 """
 function forward(model::Optimizer)
     if _qp_supported(model.optimizer)

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -176,18 +176,18 @@ struct ForwardOutVariablePrimal <: MOI.AbstractVariableAttribute end
 MOI.is_set_by_optimize(::ForwardOutVariablePrimal) = true
 
 """
-    BackwardIn{T}
+    BackwardInVariablePrimal
 
-A AbstractDiffAttribute to set input data to backward differentiation, that
-is, problem solution.
-The input data includes:
-MOI.VariablePrimal.
+A `MOI.AbstractVariableAttribute` to set input data to backward
+differentiation, that is, problem solution.
 
+For instance, to set the tangent of the variable of index `vi`, do the
+following:
 ```julia
-MOI.set(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x)
+MOI.set(model, DiffOpt.BackwardInVariablePrimal(), x)
 ```
 """
-struct BackwardIn{T} <: AbstractDiffAttribute end
+struct BackwardInVariablePrimal <: MOI.AbstractVariableAttribute end
 
 """
     BackwardOut{T}
@@ -288,10 +288,10 @@ function _get_dx(f_cache::ConicForwCache, g_cache::ConicCache, vi)
     return - (du[i] - x[i] * dw[])
 end
 
-function MOI.get(model::Optimizer, ::BackwardIn{MOI.VariablePrimal}, vi::VI)
+function MOI.get(model::Optimizer, ::BackwardInVariablePrimal, vi::VI)
     return get(model.input_cache.dx, vi, 0.0)
 end
-function MOI.set(model::Optimizer, ::BackwardIn{MOI.VariablePrimal}, vi::VI, val)
+function MOI.set(model::Optimizer, ::BackwardInVariablePrimal, vi::VI, val)
     model.input_cache.dx[vi] = val
     return
 end

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -526,7 +526,7 @@ const QP_OBJECTIVE_TYPES = Union{
 
 Wrapper method for the backward pass.
 This method will consider as input a currently solved problem and differentials
-with respect to the solution set with the [`BackwardIn`](@ref) attribute.
+with respect to the solution set with the [`BackwardInVariablePrimal`](@ref) attribute.
 The output problem data differentials can be queried with the
 attribute [`BackwardOut`](@ref).
 """
@@ -585,7 +585,7 @@ the backward pass vector `dl / dz`
 
 The method computes the product of
 1. jacobian of problem solution `z*` with respect to
-    problem parameters set with the [`BackwardIn`](@ref)
+    problem parameters set with the [`BackwardInVariablePrimal`](@ref)
 2. a backward pass vector `dl / dz`, where `l` can be a loss function
 
 Note that this method *does not returns* the actual jacobians.

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -107,32 +107,19 @@ const MOIDD = MOI.Utilities.DoubleDicts
 Base.@kwdef mutable struct DiffInputCache
     dx::Dict{VI, Float64} = Dict{VI, Float64}()# dz for QP
     # ds
-    # dy #= [d\lambada, d\nu] for QP
-    dA::MOIDD.DoubleDict{Dict{VI,Float64}} = MOIDD.DoubleDict{Dict{VI,Float64}}() # also includes G for QPs
-    dAv::MOIDD.DoubleDict{Dict{VI,Vector{Float64}}} = MOIDD.DoubleDict{Dict{VI,Vector{Float64}}}() # also includes G for QPs
-    db::MOIDD.DoubleDict{Float64} = MOIDD.DoubleDict{Float64}() # also includes h for QPs
-    dbv::MOIDD.DoubleDict{Vector{Float64}} = MOIDD.DoubleDict{Vector{Float64}}() # also includes h for QPs
+    # dy #= [d\lambda, d\nu] for QP
+    # FIXME Would it be possible to have a DoubleDict where the value depends
+    #       on the function type ? Here, we need to create two dicts to have
+    #       concrete value types.
+    # `scalar_constraints` and `vector_constraints` includes `A` and `b` for CPs
+    # or `G` and `h` for QPs
+    scalar_constraints::MOIDD.DoubleDict{MOI.ScalarAffineFunction{Float64}} = MOIDD.DoubleDict{MOI.ScalarAffineFunction{Float64}}() # also includes G for QPs
+    vector_constraints::MOIDD.DoubleDict{MOI.VectorAffineFunction{Float64}} = MOIDD.DoubleDict{MOI.VectorAffineFunction{Float64}}() # also includes G for QPs
     objective::Union{Nothing,MOI.AbstractScalarFunction} = nothing
 end
 
 abstract type AbstractDiffAttribute end
 Base.broadcastable(attribute::AbstractDiffAttribute) = Ref(attribute)
-
-"""
-    ForwardIn{T}
-
-A MOI.AbstractModelAttribute to set input data to forward differentiation, that
-is, problem input data.
-The input data includes:
-[`LinearObjective`](@ref), [`ConstraintConstant`](@ref),
-[`ConstraintCoefficient`](@ref) and [`QuadraticObjective`](@ref).
-The latter can only be used in linearly constrained quadratic models.
-
-```julia
-MOI.set(model, DiffOpt.ForwardIn{DiffOpt.LinearObjective}(), x)
-```
-"""
-struct ForwardIn{T} <: AbstractDiffAttribute end
 
 """
     ForwardInObjective
@@ -153,6 +140,24 @@ MOI.set(model, DiffOpt.ForwardInObjective(), 1.0 * fx + 2.0 * fy)
 where `x` and `y` are the relevant `MOI.VariableIndex`.
 """
 struct ForwardInObjective <: MOI.AbstractModelAttribute end
+
+"""
+    ForwardInConstraint
+
+A `MOI.AbstractConstraintAttribute` to set input data to forward differentiation, that
+is, problem input data.
+
+For instance, if the scalar constraint of index `ci` contains `θ * (x + 2y)`,
+for the purpose of computinig the derivative with respect to `θ`, the following
+should be set:
+```julia
+fx = MOI.SingleVariable(x)
+fy = MOI.SingleVariable(y)
+MOI.set(model, DiffOpt.ForwardInConstraint(), ci, 1.0 * fx + 2.0 * fy)
+```
+"""
+struct ForwardInConstraint <: MOI.AbstractConstraintAttribute end
+
 
 """
     ForwardOut{T}
@@ -379,32 +384,36 @@ function _get_db(b_cache::QPForwBackCache, g_cache::QPCache, ci::CI{F,S}
 end
 
 function MOI.get(model::Optimizer,
-    ::ForwardIn{ConstraintConstant}, ci::CI{F,S}
-) where {F<:MOI.ScalarAffineFunction,S}
-    return get(model.input_cache.db, ci, 0.0)
+    ::ForwardInConstraint, ci::CI{MOI.ScalarAffineFunction{T},S}
+) where {T,S}
+    return get(model.input_cache.scalar_constraints, ci, zero(MOI.ScalarAffineFunction{T}))
 end
 function MOI.get(model::Optimizer,
-    ::ForwardIn{ConstraintConstant}, ci::CI{F,S}
-) where {F<:MOI.VectorAffineFunction,S}
-    val = get(model.input_cache.dbv, ci, nothing)
-    if val === nothing
+    ::ForwardInConstraint, ci::CI{MOI.VectorAffineFunction{T},S}
+) where {T,S}
+    func = get(model.input_cache.vector_constraints, ci, nothing)
+    if func === nothing
         set = MOI.get(model, MOI.ConstraintSet(), ci)
         dim = MOI.dimension(set)
-        return zeros(dim)
+        return MOI.Utilities.zero_with_output_dimension(MOI.VectorAffineFunction{T}, dim)
     else
-        return val
+        return func
     end
 end
 function MOI.set(model::Optimizer,
-    ::ForwardIn{ConstraintConstant}, ci::CI{F,S}, val::Number
-) where {F<:MOI.ScalarAffineFunction,S}
-    model.input_cache.db[ci] = val
+    ::ForwardInConstraint,
+    ci::CI{MOI.ScalarAffineFunction{T},S},
+    func::MOI.ScalarAffineFunction{T},
+) where {T,S}
+    model.input_cache.scalar_constraints[ci] = func
     return
 end
 function MOI.set(model::Optimizer,
-    ::ForwardIn{ConstraintConstant}, ci::CI{F,S}, val::Vector
-) where {F<:MOI.VectorAffineFunction,S}
-    model.input_cache.dbv[ci] = val
+    ::ForwardInConstraint,
+    ci::CI{MOI.VectorAffineFunction{T},S},
+    func::MOI.VectorAffineFunction{T},
+) where {T,S}
+    model.input_cache.vector_constraints[ci] = func
     return
 end
 
@@ -477,38 +486,6 @@ function _get_dA(b_cache::QPForwBackCache, g_cache::QPCache, vi, ci::CI{F,S}
     # return λ[i] * (dλ[i] * z[j] + λ[i] * dz[j])
 end
 
-function MOI.get(model::Optimizer,
-    ::ForwardIn{ConstraintCoefficient}, vi::VI, ci::CI{F,S}) where {F,S}
-    dict = get(model.input_cache.dA, ci, nothing)
-    if dict === nothing
-        return 0.0
-    else
-        return get(dict, vi, 0.0)
-    end
-end
-function MOI.set(model::Optimizer,
-    ::ForwardIn{ConstraintCoefficient}, vi::VI, ci::CI{F,S}, val::Number
-) where {F<:MOI.ScalarAffineFunction,S}
-    dict = get(model.input_cache.dA, ci, nothing)
-    if dict === nothing
-        model.input_cache.dA[ci] = Dict(vi => val)
-    else
-        dict[vi] = val
-    end
-    return
-end
-function MOI.set(model::Optimizer,
-    ::ForwardIn{ConstraintCoefficient}, vi::VI, ci::CI{F,S}, val::Vector
-) where {F<:MOI.VectorAffineFunction,S}
-    dict = get(model.input_cache.dAv, ci, nothing)
-    if dict === nothing
-        model.input_cache.dAv[ci] = Dict(vi => val)
-    else
-        dict[vi] = val
-    end
-    return
-end
-
 
 function MOI.optimize!(model::Optimizer)
     model.gradient_cache = nothing
@@ -567,7 +544,7 @@ end
 Wrapper method for the forward pass.
 This method will consider as input a currently solved problem and
 differentials with respect to problem data set with
-the [`ForwardIn`](@ref) attribute.
+the [`ForwardInObjective`](@ref) and  [`ForwardInConstraint`](@ref) attributes.
 The output solution differentials can be queried with the attribute
 [`ForwardOut`](@ref).
 """
@@ -691,31 +668,31 @@ function _forward_quad(model::Optimizer)
     dq = sparse_array_obj.affine_terms
 
     db = zeros(length(b))
-    _fill_quad_b(model, db)
+    _fill(isequal(MOI.EqualTo{Float64}), model, _QPForm(), db)
 
     dh = zeros(length(h))
-    _fill_quad_h(model, dh)
+    _fill(!isequal(MOI.EqualTo{Float64}), model, _QPForm(), dh)
 
     nz = nnz(A)
     (lines, cols) = size(A)
-    dAv = zeros(Float64, 0)
     dAi = zeros(Int, 0)
     dAj = zeros(Int, 0)
-    sizehint!(dAv, nz)
+    dAv = zeros(Float64, 0)
     sizehint!(dAi, nz)
     sizehint!(dAj, nz)
-    _fill_quad_A(model, dAv, dAi, dAj)
+    sizehint!(dAv, nz)
+    _fill(isequal(MOI.EqualTo{Float64}), model, _QPForm(), dAi, dAj, dAv)
     dA = sparse(dAi, dAj, dAv, lines, cols)
 
     nz = nnz(G)
     (lines, cols) = size(G)
-    dGv = zeros(Float64, 0)
     dGi = zeros(Int, 0)
     dGj = zeros(Int, 0)
-    sizehint!(dGv, nz)
+    dGv = zeros(Float64, 0)
     sizehint!(dGi, nz)
     sizehint!(dGj, nz)
-    _fill_quad_G(model, dGv, dGi, dGj)
+    sizehint!(dGv, nz)
+    _fill(!isequal(MOI.EqualTo{Float64}), model, _QPForm(), dGi, dGj, dGv)
     dG = sparse(dGi, dGj, dGv, lines, cols)
 
 
@@ -739,55 +716,6 @@ function _forward_quad(model::Optimizer)
 
     model.forw_grad_cache = QPForwBackCache(dz, dλ, dν)
     return nothing
-end
-
-function _fill_quad_b(model, db)
-    conmap = model.gradient_cache.index_map.conmap
-    dict_db = model.input_cache.db
-    SA = MOI.ScalarAffineFunction{Float64}
-    SV = MOI.SingleVariable
-    EQ = MOI.EqualTo{Float64}
-    _fill_array(model, db, conmap[SA,EQ], dict_db[SA,EQ])
-    _fill_array(model, db, conmap[SV,EQ], dict_db[SV,EQ])
-    return
-end
-function _fill_quad_h(model, dh)
-    conmap = model.gradient_cache.index_map.conmap
-    dict_db = model.input_cache.db
-    SA = MOI.ScalarAffineFunction{Float64}
-    SV = MOI.SingleVariable
-    GT = MOI.GreaterThan{Float64}
-    LT = MOI.LessThan{Float64}
-    _fill_array(model, dh, conmap[SA,LT], dict_db[SA,LT])
-    _fill_array(model, dh, conmap[SV,LT], dict_db[SV,LT])
-    _fill_array(model, dh, conmap[SA,GT], dict_db[SA,GT])
-    _fill_array(model, dh, conmap[SV,GT], dict_db[SV,GT])
-    return
-end
-function _fill_quad_A(model, dAv, dAi, dAj)
-    conmap = model.gradient_cache.index_map.conmap
-    varmap = model.gradient_cache.index_map.varmap
-    dict_dA = model.input_cache.dA
-    SA = MOI.ScalarAffineFunction{Float64}
-    SV = MOI.SingleVariable
-    EQ = MOI.EqualTo{Float64}
-    _fill_matrix(model, dAv, dAi, dAj, conmap[SA,EQ], dict_dA[SA,EQ], varmap, 0)
-    _fill_matrix(model, dAv, dAi, dAj, conmap[SV,EQ], dict_dA[SV,EQ], varmap, 0)
-    return
-end
-function _fill_quad_G(model, dGv, dGi, dGj)
-    conmap = model.gradient_cache.index_map.conmap
-    varmap = model.gradient_cache.index_map.varmap
-    dict_dG = model.input_cache.dA
-    SA = MOI.ScalarAffineFunction{Float64}
-    SV = MOI.SingleVariable
-    GT = MOI.GreaterThan{Float64}
-    LT = MOI.LessThan{Float64}
-    _fill_matrix(model, dGv, dGi, dGj, conmap[SA,LT], dict_dG[SA,LT], varmap, 0)
-    _fill_matrix(model, dGv, dGi, dGj, conmap[SV,LT], dict_dG[SV,LT], varmap, 0)
-    _fill_matrix(model, dGv, dGi, dGj, conmap[SA,GT], dict_dG[SA,GT], varmap, 0)
-    _fill_matrix(model, dGv, dGi, dGj, conmap[SV,GT], dict_dG[SV,GT], varmap, 0)
-    return
 end
 
 
@@ -924,16 +852,16 @@ function _forward_conic(model::Optimizer)
     dc = sparse_array_obj.terms
 
     db = zeros(length(b))
-    _fill_conic_b(model, db)
+    _fill(model, model.gradient_cache.conic_form, db)
     (lines, cols) = size(A)
     nz = nnz(A)
-    dAv = zeros(Float64, 0)
     dAi = zeros(Int, 0)
     dAj = zeros(Int, 0)
-    sizehint!(dAv, nz)
+    dAv = zeros(Float64, 0)
     sizehint!(dAi, nz)
     sizehint!(dAj, nz)
-    _fill_conic_A(model, dAv, dAi, dAj)
+    sizehint!(dAv, nz)
+    _fill(model, model.gradient_cache.conic_form, dAi, dAj, dAv)
     dA = sparse(dAi, dAj, dAv, lines, cols)
 
     m = size(A, 1)
@@ -960,81 +888,48 @@ function _forward_conic(model::Optimizer)
     # return -dx, -dy, -ds
 end
 
-# VI is one base
-function _fill_array(model, array, map, dict)
-    for (ci, val) in dict
-        i = map[ci].value
-        array[i] = val
-    end
-end
+# Just a hack that will be removed once we use `MOIU.MatrixOfConstraints`
+struct _QPForm end
+MatOI.rows(::_QPForm, ci::MOI.ConstraintIndex) = ci.value
 
-# CI is zero based
-function _fill_array_c(model, array, map, dict)
-    for (ci, val) in dict
-        i = map[ci].value
-        _push_terms(array, val, i)
-    end
+function _fill(model::Optimizer, conic_form, args...)
+    _fill(S -> true, model, conic_form, args...)
 end
-function _push_terms(array, val::Number, i)
-    array[i+1] = val
-    return
-end
-function _push_terms(array, val::Vector, i)
-    for k in eachindex(val)
-        array[i + k] = val[k]
-    end
-    return
-end
-
-function _fill_conic_b(model, db)
-    conmap = model.gradient_cache.index_map.conmap
-    dict_db = model.input_cache.db
-    for (F, S) in MOI.get(model, MOI.ListOfConstraints())
-        _fill_array_c(model, db, conmap[F,S], dict_db[F,S])
-    end
-    dict_dbv = model.input_cache.dbv
-    for (F, S) in MOI.get(model, MOI.ListOfConstraints())
-        _fill_array_c(model, db, conmap[F,S], dict_dbv[F,S])
-    end
-    return
-end
-
-function _fill_conic_A(model, dAv, dAi, dAj)
+function _fill(filter::Function, model::Optimizer, conic_form, args...)
     conmap = model.gradient_cache.index_map.conmap
     varmap = model.gradient_cache.index_map.varmap
-    dict_dA = model.input_cache.dA
     for (F, S) in MOI.get(model, MOI.ListOfConstraints())
-        _fill_matrix(model, dAv, dAi, dAj, conmap[F,S], dict_dA[F,S], varmap)
-    end
-    dict_dAv = model.input_cache.dAv
-    for (F, S) in MOI.get(model, MOI.ListOfConstraints())
-        _fill_matrix(model, dAv, dAi, dAj, conmap[F,S], dict_dAv[F,S], varmap)
-    end
-    return
-end
-function _fill_matrix(model, dAv, dAi, dAj, conmap, dict_dA, varmap, start = 1)
-    for (ci, dict) in dict_dA
-        i = conmap[ci].value
-        for (vi, val) in dict
-            j = varmap[vi].value
-            _push_terms(dAv, dAi, dAj, val, i+start, j)
+        filter(S) || continue
+        if F == MOI.ScalarAffineFunction{Float64}
+            _fill(args..., conic_form, conmap[F,S], varmap, model.input_cache.scalar_constraints[F,S])
+        elseif F == MOI.VectorAffineFunction{Float64}
+            _fill(args..., conic_form, conmap[F,S], varmap, model.input_cache.vector_constraints[F,S])
         end
     end
     return
 end
-function _push_terms(dAv, dAi, dAj, val::Number, i, j)
-    push!(dAv, val)
-    push!(dAi, i)# + 1)
-    push!(dAj, j)
-    return
-end
-function _push_terms(dAv, dAi, dAj, val::Vector, i, j)
-    for k in eachindex(val)
-        push!(dAv, val[k])
-        push!(dAi, i + k - 1) # ci is zero based
-        push!(dAj, j)
+
+function _fill(vector::Vector, conic_form, constraint_map, variable_map, dict)
+    for (ci, func) in dict
+        r = MatOI.rows(conic_form, constraint_map[ci])
+        vector[r] = MOI.constant(func)
     end
-    return
+end
+function _fill(I::Vector, J::Vector, V::Vector, conic_form, constraint_map, variable_map, dict)
+    for (ci, func) in dict
+        r = MatOI.rows(conic_form, constraint_map[ci])
+        for term in func.terms
+            _push_term(I, J, V, r, term, variable_map)
+        end
+    end
+end
+function _push_term(I::Vector, J::Vector, V::Vector, r::Integer, term::MOI.ScalarAffineTerm, variable_map)
+    push!(I, r)
+    push!(J, variable_map[term.variable_index].value)
+    push!(V, term.coefficient)
+end
+function _push_term(I::Vector, J::Vector, V::Vector, r::UnitRange, term::MOI.VectorAffineTerm, variable_map)
+    _push_term(I, J, V, r[term.output_index], term.scalar_term, variable_map)
 end
 
 """

--- a/src/jump_moi_overloads.jl
+++ b/src/jump_moi_overloads.jl
@@ -1,3 +1,13 @@
+function set_forward_diff_objective(model::JuMP.Model, func::MOI.AbstractScalarFunction)
+    MOI.set(model, ForwardInObjective{typeof(func)}(), func)
+    return
+end
+function set_forward_diff_objective(model::JuMP.Model, func::JuMP.AbstractJuMPScalar)
+    JuMP.check_belongs_to_model(func, model)
+    return set_forward_diff_objective(model, JuMP.moi_function(func))
+end
+
+
 # extend caching optimizer
 function MOI.set(
     m::MOI.Utilities.CachingOptimizer,

--- a/src/jump_moi_overloads.jl
+++ b/src/jump_moi_overloads.jl
@@ -1,10 +1,6 @@
-function set_forward_diff_objective(model::JuMP.Model, func::MOI.AbstractScalarFunction)
-    MOI.set(model, ForwardInObjective{typeof(func)}(), func)
-    return
-end
-function set_forward_diff_objective(model::JuMP.Model, func::JuMP.AbstractJuMPScalar)
+function MOI.set(model::JuMP.Model, ::ForwardInObjective, func::JuMP.AbstractJuMPScalar)
     JuMP.check_belongs_to_model(func, model)
-    return set_forward_diff_objective(model, JuMP.moi_function(func))
+    return MOI.set(model, ForwardInObjective(), JuMP.moi_function(func))
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,3 +54,5 @@ function sparse_array_representation(func::MOI.ScalarQuadraticFunction, num_vari
         func.constant,
     )
 end
+_convert(::Type{F}, ::Nothing) where {F} = zero(F)
+_convert(::Type{F}, obj) where {F} = convert(F, obj)

--- a/test/conic_backward.jl
+++ b/test/conic_backward.jl
@@ -42,7 +42,7 @@
 
     @test x ≈ ones(3) atol=ATOL rtol=RTOL
 
-    MOI.set(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), X[1], 1.0)
+    MOI.set(model, DiffOpt.BackwardInVariablePrimal(), X[1], 1.0)
 
     DiffOpt.backward(model)
 

--- a/test/jump.jl
+++ b/test/jump.jl
@@ -69,7 +69,7 @@ end
 
     # grad_wrt_h = backward(JuMP.backend(model), ["h"], ones(2))[1]
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, 1.0)
 
     DiffOpt.backward(model)
 
@@ -120,7 +120,7 @@ end
 
     @test JuMP.value.(x) ≈ [0.0, 0.5, 0.0] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, 1.0)
 
     DiffOpt.backward(model)
 
@@ -195,7 +195,7 @@ end
 
     @test JuMP.value.(z) ≈ [4/7, 3/7, 6/7] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), z, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), z, 1.0)
 
     DiffOpt.backward(model)
 
@@ -249,7 +249,7 @@ end
 
     @test JuMP.value.(z) ≈ [0.25, 0.75] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), z, [1.3, 0.5])
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), z, [1.3, 0.5])
 
     DiffOpt.backward(model)
 
@@ -322,7 +322,7 @@ end
 
     optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, 1.0)
 
     DiffOpt.backward(model)
 
@@ -385,7 +385,7 @@ end
     optimize!(model)
 
     # obtain gradients
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, 1.0)
 
     DiffOpt.backward(model)
 
@@ -414,7 +414,7 @@ end
 
     optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, 1.0)
 
     DiffOpt.backward(model)
 
@@ -452,7 +452,7 @@ end
     @constraint(model, c2, 2x+5y+3z <= 15)
     optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, 1.0)
 
     DiffOpt.backward(model)
 
@@ -515,7 +515,7 @@ end
 
     optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, 1.0)
 
     DiffOpt.backward(model)
 
@@ -603,7 +603,7 @@ end
     db = zeros(5)
     dc = zeros(3)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), vv, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), vv, 1.0)
 
     @test_broken DiffOpt.backward(model)
 

--- a/test/moi_wrapper.jl
+++ b/test/moi_wrapper.jl
@@ -1082,7 +1082,7 @@ end
 
     dx = [1.12132144; 1/√2; 1/√2]
     for (i, vi) in enumerate(v)
-        @test dx[i] ≈ MOI.get(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=ATOL rtol=RTOL
+        @test dx[i] ≈ MOI.get(model, DiffOpt.ForwardOutVariablePrimal(), vi) atol=ATOL rtol=RTOL
     end
     # @test dx ≈ [1.12132144; 1/√2; 1/√2] atol=ATOL rtol=RTOL
     # @test ds ≈ [0.0; 0.0; -2.92893438e-01;  1.12132144e+00; 7.07106999e-01]  atol=ATOL rtol=RTOL
@@ -1148,7 +1148,7 @@ function simple_psd(solver)
 
     dx = -ones(3)
     for (i, vi) in enumerate(X)
-        @test dx[i] ≈ MOI.get(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=ATOL rtol=RTOL
+        @test dx[i] ≈ MOI.get(model, DiffOpt.ForwardOutVariablePrimal(), vi) atol=ATOL rtol=RTOL
     end
 
     # @test dx ≈ -ones(3) atol=ATOL rtol=RTOL  # will change the value of other 2 variables
@@ -1163,7 +1163,7 @@ function simple_psd(solver)
     # @test dx ≈ [1.0, 0.0, -1.0] atol=ATOL rtol=RTOL  # note: no effect on X[2]
     dx = [1.0, 0.0, -1.0]
     for (i, vi) in enumerate(X)
-        @test dx[i] ≈ MOI.get(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=ATOL rtol=RTOL
+        @test dx[i] ≈ MOI.get(model, DiffOpt.ForwardOutVariablePrimal(), vi) atol=ATOL rtol=RTOL
     end
 end
 
@@ -1300,11 +1300,11 @@ end
     # a small change in the constant in c_extra should not affect any other variable or constraint other than c_extra itself
     for (i, vi) in enumerate(X)
         @test 0.0 ≈ MOI.get(model,
-            DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=1e-2 rtol=RTOL
+            DiffOpt.ForwardOutVariablePrimal(), vi) atol=1e-2 rtol=RTOL
     end
     for (i, vi) in enumerate(x)
         @test 0.0 ≈ MOI.get(model,
-            DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=1e-2 rtol=RTOL
+            DiffOpt.ForwardOutVariablePrimal(), vi) atol=1e-2 rtol=RTOL
     end
     # @test dx ≈ zeros(9) atol=1e-2
     # @test dy ≈ zeros(12) atol=0.012
@@ -1404,7 +1404,7 @@ end
     dx = [-39.6066, 10.8953, -14.9189, 10.9054, 10.883, 10.9118, -21.7508]
     for (i, vi) in enumerate(x)
         @test dx[i] ≈ MOI.get(model,
-            DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=atol rtol=rtol
+            DiffOpt.ForwardOutVariablePrimal(), vi) atol=atol rtol=rtol
     end
     # @test dy ≈ [0.0, -3.56905, 0.0, -0.380035, 0.0, -0.41398, -0.385321, -0.00743119, -0.644986, -0.550542, -2.36765] atol=atol rtol=rtol
     # @test ds ≈ [0.0, 0.0, -50.4973, 0.0, -25.8066, 0.0, 0.0, 0.0, -7.96528, -1.62968, -2.18925] atol=atol rtol=rtol
@@ -1432,7 +1432,7 @@ end
 
     # for (i, vi) in enumerate(X)
     #     @test 0.0 ≈ MOI.get(model,
-    #         DiffOpt.ForwardOut{MOI.VariablePrimal}(), vi) atol=1e-2 rtol=RTOL
+    #         DiffOpt.ForwardOutVariablePrimal(), vi) atol=1e-2 rtol=RTOL
     # end
 
     # TODO add a test here, probably on duals
@@ -1499,7 +1499,7 @@ end
     DiffOpt.forward(model)
 
     @test -0.5 ≈ MOI.get(model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), x) atol=1e-2 rtol=RTOL
+        DiffOpt.ForwardOutVariablePrimal(), x) atol=1e-2 rtol=RTOL
 
     # @test dx ≈ [-0.5] atol=ATOL rtol=RTOL
     # @test dy ≈ zeros(6) atol=ATOL rtol=RTOL
@@ -1515,7 +1515,7 @@ end
     DiffOpt.forward(model)
 
     @test 0.0 ≈ MOI.get(model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), x) atol=1e-2 rtol=RTOL
+        DiffOpt.ForwardOutVariablePrimal(), x) atol=1e-2 rtol=RTOL
 
     # @test dx ≈ zeros(1) atol=ATOL rtol=RTOL
     # @test dy ≈ [0.333333, -0.333333, 0.333333, -0.333333, -0.333333, 0.333333] atol=ATOL rtol=RTOL
@@ -1672,7 +1672,7 @@ end
     DiffOpt.forward(model)
 
     @test -0.5 ≈ MOI.get(model,
-    DiffOpt.ForwardOut{MOI.VariablePrimal}(), x) atol=1e-2 rtol=RTOL
+    DiffOpt.ForwardOutVariablePrimal(), x) atol=1e-2 rtol=RTOL
 
     # @test dx ≈ [-0.5] atol=ATOL rtol=RTOL
     # @test dy ≈ zeros(6) atol=ATOL rtol=RTOL
@@ -1683,7 +1683,7 @@ end
     DiffOpt.forward(model)
 
     @test -0.5 ≈ MOI.get(model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), x) atol=1e-2 rtol=RTOL
+        DiffOpt.ForwardOutVariablePrimal(), x) atol=1e-2 rtol=RTOL
 
     # dx2, dy2, ds2 = _backward_conic(model, dA, db, dc)
     # @test all(
@@ -1698,7 +1698,7 @@ end
     DiffOpt.forward(model)
 
     @test 0.0 ≈ MOI.get(model,
-        DiffOpt.ForwardOut{MOI.VariablePrimal}(), x) atol=1e-2 rtol=RTOL
+        DiffOpt.ForwardOutVariablePrimal(), x) atol=1e-2 rtol=RTOL
 
     # @test dx ≈ zeros(1) atol=ATOL rtol=RTOL
     # @test dy ≈ [0.333333, -0.333333, 0.333333, -0.333333, -0.333333, 0.333333] atol=ATOL rtol=RTOL

--- a/test/moi_wrapper.jl
+++ b/test/moi_wrapper.jl
@@ -108,7 +108,7 @@ end
 
     @test x_sol ≈ [-0.25; -0.75] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 
     DiffOpt.backward(model)
 
@@ -226,7 +226,7 @@ end
 
     @test z ≈ [0.0, 0.5, 0.0] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(3))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(3))
 
     DiffOpt.backward(model)#, ["Q","q","G","h","A","b"], ones(3))
 
@@ -319,7 +319,7 @@ end
 
     @test z ≈ [4/7, 3/7, 6/7] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, ones(3))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, ones(3))
 
     # obtain gradients
     # grads = backward(model, ["Q","q","G","h"], ones(3))
@@ -409,7 +409,7 @@ end
 
     v = [x, y]
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), [x, y], [1.3, 0.5])
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), [x, y], [1.3, 0.5])
 
     DiffOpt.backward(model)
 
@@ -512,7 +512,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, ones(nz))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, ones(nz))
 
     DiffOpt.backward(model)
 
@@ -578,7 +578,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, 1.0)
 
     DiffOpt.backward(model)
 
@@ -618,7 +618,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, 1.0)
 
     DiffOpt.backward(model)
 
@@ -685,7 +685,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, ones(3))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, ones(3))
 
     DiffOpt.backward(model)
 
@@ -788,7 +788,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, ones(3))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, ones(3))
 
     DiffOpt.backward(model)
 
@@ -867,7 +867,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, ones(3))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, ones(3))
 
     DiffOpt.backward(model)
 
@@ -988,7 +988,7 @@ end
 
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), v, 1.0)
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), v, 1.0)
 
     DiffOpt.backward(model)
 
@@ -1564,7 +1564,7 @@ end
     x_sol = MOI.get(model, MOI.VariablePrimal(), x)
     @test x_sol ≈ [-0.25, -0.75] atol=ATOL rtol=RTOL
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 
     @test model.gradient_cache === nothing
     DiffOpt.backward(model)
@@ -1584,7 +1584,7 @@ end
     @test model.gradient_cache === nothing
     MOI.optimize!(model)
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
     DiffOpt.backward(model)
 
     grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
@@ -1599,7 +1599,7 @@ end
     MOI.optimize!(model)
     @test model.gradient_cache === nothing
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
     DiffOpt.backward(model)
     # grad_wrt_h = backward(model, ["h"], ones(3))[1]
     grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
@@ -1616,7 +1616,7 @@ end
     MOI.optimize!(model)
 
 
-    MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+    MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
     DiffOpt.backward(model)
     # grad_wrt_h = backward(model, ["h"], ones(3))[1]
     grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)

--- a/test/moi_wrapper.jl
+++ b/test/moi_wrapper.jl
@@ -1167,8 +1167,7 @@ function simple_psd(solver)
     dA = zeros(4, 3)
     db = zeros(4)
     MOI.set(model, DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c, [0.0])
-    dobj = -1.0fX[1] + 1.0fX[3]
-    MOI.set(model, DiffOpt.ForwardInObjective{typeof(dobj)}(), dobj)
+    MOI.set(model, DiffOpt.ForwardInObjective(), -1.0fX[1] + 1.0fX[3])
 
     DiffOpt.forward(model)
 
@@ -1397,9 +1396,7 @@ end
     @test y ≈ [0.0, 0.19019238, 0., 0.12597667, 0., 0.14264428, 0.14264428, 0.01274047, 0.21132487, 0.408248, 0.78867513] atol=ATOL rtol=RTOL
 
     # dc = ones(7)
-    dobj = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(7), x), 0.0)
-    MOI.set.(model,
-        DiffOpt.ForwardInObjective{typeof(dobj)}(), dobj)
+    MOI.set(model, DiffOpt.ForwardInObjective(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(7), x), 0.0))
     # db = ones(11)
     MOI.set(model,
         DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c1, [1.0])
@@ -1550,8 +1547,7 @@ end
     dA = zeros(6, 1)
     db = zeros(6)
     MOI.set(model, DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c, zeros(6))
-    dobj = 1.0 * MOI.SingleVariable(x)
-    MOI.set(model, DiffOpt.ForwardInObjective{typeof(dobj)}(), dobj)
+    MOI.set(model, DiffOpt.ForwardInObjective(), 1.0 * MOI.SingleVariable(x))
 
     # dx, dy, ds = backward(model, dA, db, dc)
     DiffOpt.forward(model)
@@ -1736,8 +1732,7 @@ end
     dA = zeros(6, 1)
     db = zeros(6)
     MOI.set(model, DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c, zeros(6))
-    dobj = 1.0 * MOI.SingleVariable(x)
-    MOI.set(model, DiffOpt.ForwardInObjective{typeof(dobj)}(), dobj)
+    MOI.set(model, DiffOpt.ForwardInObjective(), 1.0 * MOI.SingleVariable(x))
 
     # dx, dy, ds = _backward_conic(model, dA, db, dc)
     DiffOpt.forward(model)

--- a/test/qp_forward.jl
+++ b/test/qp_forward.jl
@@ -36,6 +36,6 @@
 
     DiffOpt.forward(model)
 
-    dx = MOI.get(model, DiffOpt.ForwardOut{MOI.VariablePrimal}(), v[])
+    dx = MOI.get(model, DiffOpt.ForwardOutVariablePrimal(), v[])
     @test dx ≈ 1.0  atol=ATOL rtol=RTOL
 end

--- a/test/qp_forward.jl
+++ b/test/qp_forward.jl
@@ -32,7 +32,7 @@
 
     MOI.optimize!(model)
 
-    MOI.set(model, DiffOpt.ForwardIn{DiffOpt.ConstraintConstant}(), c2, 1.0)
+    MOI.set(model, DiffOpt.ForwardInConstraint(), c2, convert(MOI.ScalarAffineFunction{Float64}, 1.0))
 
     DiffOpt.forward(model)
 

--- a/test/singular_exception.jl
+++ b/test/singular_exception.jl
@@ -45,7 +45,7 @@ MOI.optimize!(model)
 @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [-0.25; -0.75] atol=ATOL rtol=RTOL
 
 @test model.gradient_cache === nothing
-MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 DiffOpt.backward(model)
 
 grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
@@ -61,7 +61,7 @@ end
 @test model.gradient_cache === nothing
 MOI.optimize!(model)
 
-MOI.set.(model, DiffOpt.BackwardIn{MOI.VariablePrimal}(), x, ones(2))
+MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 DiffOpt.backward(model)
 
 grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)


### PR DESCRIPTION
As detailed in https://github.com/jump-dev/DiffOpt.jl/issues/114, it would be better to have subtype of `MOI.AbstractModelAttribute`.
Having the type of the function in the attribute is needed to have a type-stable getter similarly to `MOI.ObjectiveFunction`. Probably it's not so critical this time so we can remove it (which is done in the second commit), it's mostly used in `MOI.ObjectiveFunction` for supports so that we can compute the objective bridge graph but we are probably not going to create bridges for ForwardInObjective.