### PR TITLE
BackwardOut -> BackwardOutConstraint

### DIFF
--- a/docs/src/chainrules_unit.md
+++ b/docs/src/chainrules_unit.md
@@ -244,7 +244,7 @@ function ChainRulesCore.rrule(
         dnoload_costs[2] = sum(JuMP.coefficient.(obj, u[2,:]))
 
         # computing derivative wrt constraint constant
-        dload1_demand = MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), energy_balance_cons)
+        dload1_demand = JuMP.constant.(MOI.get.(model, DiffOpt.BackwardOutConstraint(), energy_balance_cons))
         dload2_demand = copy(dload1_demand)
         return (dload1_demand, dload2_demand, dgen_costs, dnoload_costs)
     end

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -34,7 +34,7 @@ MOI.set.(model,
     DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 DiffOpt.backward(model)
 grad_obj = MOI.get(model, DiffOpt.BackwardOutObjective())
-grad_rhs = MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
+grad_con = MOI.get.(model, DiffOpt.BackwardOutConstraint(), c)
 ```
 
 2. To differentiate convex conic program

--- a/examples/chainrules.jl
+++ b/examples/chainrules.jl
@@ -90,7 +90,7 @@ function ChainRulesCore.frule((_, Δload1_demand, Δload2_demand, Δgen_costs, �
     MOI.set.(
         model,
         DiffOpt.ForwardInConstraint(), energy_balance_cons,
-        [convert(MOI.ScalarAffineFunction{Float64}, d1 + d2) for (d1, d2) in zip(Δload1_demand, Δload2_demand)],
+        AffExpr[d1 + d2 for (d1, d2) in zip(Δload1_demand, Δload2_demand)],
     )
 
     p = model[:p]
@@ -143,7 +143,7 @@ function ChainRulesCore.rrule(::typeof(unit_commitment), load1_demand, load2_dem
         dnoload_costs[2] = sum(JuMP.coefficient.(obj, u[2,:]))
 
         # computing derivative wrt constraint constant
-        dload1_demand = MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), energy_balance_cons)
+        dload1_demand = JuMP.constant.(MOI.get.(model, DiffOpt.BackwardOutConstraint(), energy_balance_cons))
         dload2_demand = copy(dload1_demand)
         return (dload1_demand, dload2_demand, dgen_costs, dnoload_costs)
     end

--- a/examples/unit_example.jl
+++ b/examples/unit_example.jl
@@ -68,6 +68,6 @@ grad = MOI.get(diff_opt, DiffOpt.BackwardOutObjective())
 
 # sensitivity wrt RHS of constraints
 for (idx, econs) in enumerate(energy_balance_cons)
-    grad_energy_balance = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), econs)
+    grad_energy_balance = JuMP.constant(MOI.get(model, DiffOpt.BackwardOutConstraint(), econs))
     @test !≈(grad_energy_balance, 0)
 end

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -470,7 +470,7 @@ function _get_dA(b_cache::QPForwBackCache, g_cache::QPCache, ci::CI)
     dz = b_cache.dz
     λ = g_cache.inequality_duals
     dλ = b_cache.dλ
-    return λ[i] * (dλ[i] * z + λ[i] * dz)
+    return lazy_combination(+, λ[i] * dλ[i], z, λ[i] * λ[i], dz)
 end
 
 
@@ -513,7 +513,7 @@ Wrapper method for the backward pass.
 This method will consider as input a currently solved problem and differentials
 with respect to the solution set with the [`BackwardInVariablePrimal`](@ref) attribute.
 The output problem data differentials can be queried with the
-attribute [`BackwardOut`](@ref).
+attributes [`BackwardOutObjective`](@ref) and [`BackwardOutConstraint`](@ref).
 """
 function backward(model::Optimizer)
     if _qp_supported(model.optimizer)

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -326,6 +326,13 @@ function MOI.set(model::Optimizer, ::ForwardInObjective, objective)
     return
 end
 
+# Workaround for Julia v1.0
+@static if VERSION < v"1.6"
+    _view(x, I) = x[I]
+else
+    _view(x, I) = view(x, I)
+end
+
 _lazy_affine(vector, constant::Number) = VectorScalarAffineFunction(vector, constant)
 _lazy_affine(matrix, vector) = MatrixVectorAffineFunction(matrix, vector)
 function MOI.get(model::Optimizer, ::BackwardOutConstraint, ci::CI)
@@ -349,8 +356,8 @@ function _get_db(b_cache::ConicBackCache, g_cache::ConicCache, ci::CI{F,S}
     I = n .+ i
     return LazyArrays.ApplyArray(
         -,
-        LazyArrays.@~(πz[end] .* view(g, I)),
-        LazyArrays.@~(g[end] .* view(πz, I)),
+        LazyArrays.@~(πz[end] .* _view(g, I)),
+        LazyArrays.@~(g[end] .* _view(πz, I)),
     )
 end
 function _get_db(b_cache::ConicBackCache, g_cache::ConicCache, ci::CI{F,S}
@@ -427,8 +434,8 @@ function _get_dA(b_cache::ConicBackCache, g_cache::ConicCache, ci::CI{F,S}
     I = n .+ (1:n)
     return LazyArrays.ApplyArray(
         -,
-        LazyArrays.@~(g[i] .* view(πz, I)),
-        LazyArrays.@~(πz[i] .* view(g, I)),
+        LazyArrays.@~(g[i] .* _view(πz, I)),
+        LazyArrays.@~(πz[i] .* _view(g, I)),
     )
 end
 function _get_dA(b_cache::ConicBackCache, g_cache::ConicCache, ci::CI{F,S}
@@ -446,8 +453,8 @@ function _get_dA(b_cache::ConicBackCache, g_cache::ConicCache, ci::CI{F,S}
     I = n .+ (1:n)
     return LazyArrays.ApplyArray(
         -,
-        LazyArrays.@~(g[i] .* view(πz, I)),
-        LazyArrays.@~(πz[i] .* view(g, I)),
+        LazyArrays.@~(g[i] .* _view(πz, I)),
+        LazyArrays.@~(πz[i] .* _view(g, I)),
     )
 end
 # quadratic matrix indexes are split by type either == or (<=/>=)

--- a/src/quadratic_diff.jl
+++ b/src/quadratic_diff.jl
@@ -15,14 +15,14 @@ function build_quad_diff_cache!(model)
 
     # separate λ, ν
 
-    λ = MOI.get.(model.optimizer, MOI.ConstraintDual(), le_con_idx)
+    λ = -MOI.get.(model.optimizer, MOI.ConstraintDual(), le_con_idx)
     append!(
         λ,
         MOI.get.(model.optimizer, MOI.ConstraintDual(), ge_con_idx),
     )
     append!(
         λ,
-        MOI.get.(model.optimizer, MOI.ConstraintDual(), le_con_sv_idx),
+        -MOI.get.(model.optimizer, MOI.ConstraintDual(), le_con_sv_idx),
     )
     append!(
         λ,

--- a/test/conic_backward.jl
+++ b/test/conic_backward.jl
@@ -46,7 +46,7 @@
 
     DiffOpt.backward(model)
 
-    db = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
+    db = MOI.constant(MOI.get(model, DiffOpt.BackwardOutConstraint(), c))
 
     @test db ≈ [-1.0]  atol=ATOL rtol=RTOL
 end

--- a/test/singular_exception.jl
+++ b/test/singular_exception.jl
@@ -48,7 +48,7 @@ MOI.optimize!(model)
 MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 DiffOpt.backward(model)
 
-grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
+grad_wrt_h = MOI.constant(MOI.get(model, DiffOpt.BackwardOutConstraint(), c))
 # grad_wrt_h = backward(model, ["h"], ones(2))[1]
 @test grad_wrt_h ≈ 1.0 atol=2ATOL rtol=RTOL
 @test model.gradient_cache !== nothing
@@ -64,7 +64,7 @@ MOI.optimize!(model)
 MOI.set.(model, DiffOpt.BackwardInVariablePrimal(), x, ones(2))
 DiffOpt.backward(model)
 
-grad_wrt_h = MOI.get(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), c)
+grad_wrt_h = MOI.constant(MOI.get(model, DiffOpt.BackwardOutConstraint(), c))
 
 # grad_wrt_h = backward(model, ["h"], ones(2))[1]
 @test grad_wrt_h ≈ 1.0 atol=1e-3

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -125,36 +125,12 @@ function qp_test(
         @_test(spb.quadratic_terms, dQb)
         @_test(spb.affine_terms, dqb)
 
-        @_test(
-            convert(Vector{Float64}, MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), cle)),
-            dhb,
-        )
-        @_test(
-            Float64[
-                MOI.get(
-                    model,
-                    DiffOpt.BackwardOut{DiffOpt.ConstraintCoefficient}(),
-                    vi,
-                    ci,
-                ) for ci in cle, vi in v
-            ],
-            dGb,
-        )
-        @_test(
-            convert(Vector{Float64}, MOI.get.(model, DiffOpt.BackwardOut{DiffOpt.ConstraintConstant}(), ceq)),
-            dbb,
-        )
-        @_test(
-            Float64[
-                MOI.get(
-                    model,
-                    DiffOpt.BackwardOut{DiffOpt.ConstraintCoefficient}(),
-                    vi,
-                    ci,
-                ) for ci in ceq, vi in v
-            ],
-            dAb,
-        )
+        funcs = MOI.get.(model, DiffOpt.BackwardOutConstraint(), cle)
+        @_test(convert(Vector{Float64}, MOI.constant.(funcs)), dhb)
+        @_test(Float64[JuMP.coefficient(funcs[i], vi) for i in eachindex(cle), vi in v], dGb)
+        funcs = MOI.get.(model, DiffOpt.BackwardOutConstraint(), ceq)
+        @_test(convert(Vector{Float64}, MOI.constant.(funcs)), dbb)
+        @_test(Float64[JuMP.coefficient(funcs[i], vi) for i in eachindex(ceq), vi in v], dAb)
     end
 
     # Test against [AK17, eq. (8)]


### PR DESCRIPTION
By converting the test "Differentiating MOI examples 1" to `qp_test`, the test was failing and I was able to fix it by doing the changes suggested in https://github.com/jump-dev/DiffOpt.jl/issues/124 and https://github.com/jump-dev/DiffOpt.jl/issues/127.
So I'm quite confident on the changes on these lines.

Closes https://github.com/jump-dev/DiffOpt.jl/issues/124
Closes https://github.com/jump-dev/DiffOpt.jl/issues/127