### PR TITLE
Allow setting explicit problem class

### DIFF
--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -249,7 +249,7 @@ different program class:
 2) Conic Program (CP): linear objective and conic constraints.
 
 `AUTOMATIC` which means that the class will be automatically selected given the
-problem data: if any constraint is conic, QP is used and CP is used otherwise.
+problem data: if any constraint is conic, CP is used and QP is used otherwise.
 See [`ProgramClass`](@ref).
 """
 @enum ProgramClassCode QUADRATIC CONIC AUTOMATIC

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -324,7 +324,7 @@ struct ProgramClassUsed <: MOI.AbstractOptimizerAttribute end
 
 function MOI.get(model::Optimizer, ::ProgramClassUsed)
     if model.program_class == AUTOMATIC
-        if _qp_supported(model)
+        if _qp_supported(model.optimizer)
             return QUADRATIC
         else
             return CONIC

--- a/src/quadratic_diff.jl
+++ b/src/quadratic_diff.jl
@@ -127,7 +127,7 @@ const _QP_FUNCTION_TYPES = Union{
 
 _qp_supported(::Type{F}, ::Type{S}) where {F <: _QP_FUNCTION_TYPES, S <: _QP_SET_TYPES} = true
 _qp_supported(::Type{F}, ::Type{S}) where {F, S} = false
-function _qp_supported(model::Optimizer)
+function _qp_supported(model::MOI.AbstractOptimizer)
     return all(FS -> _qp_supported(FS...), MOI.get(model, MOI.ListOfConstraints()))
 end
 


### PR DESCRIPTION
One design decision here would be: do we want to have this as type parameter of `Optimizer` or as a field ? The advantage of a field is that it can be set with optimizer attributes and change at will while even if it may not make much sense to change it once a few constraints have already been passed and bridges have been chosen in view of the program class. But a user may want to change the class, empty and copy again, that would make sense.
Let me know what you think