### PR TITLE
Add explanation and fix typo in some tutorials

### DIFF
--- a/docs/src/examples/custom-relu.jl
+++ b/docs/src/examples/custom-relu.jl
@@ -135,4 +135,4 @@ accuracy(test_X, test_Y)
 
 # Note that the accuracy is low due to simplified training.
 # It is possible to increase the number of samples `N`,
-# the number of epochs `epoch` and teh conectivity `inner`.
+# the number of epochs `epoch` and the connectivity `inner`.

--- a/docs/src/examples/custom-relu.jl
+++ b/docs/src/examples/custom-relu.jl
@@ -64,7 +64,7 @@ function ChainRulesCore.rrule(
             obj_exp = MOI.get(
                 model,
                 DiffOpt.BackwardOutObjective()
-            ) # return grdiente wrt objective function parameters
+            ) # return gradient wrt objective function parameters
             dy[:, i] = JuMP.coefficient.(obj_exp, x) # coeff of `x` in -2x'y
             dy[:, i] = -2 * dy[:, i]
         end

--- a/docs/src/examples/matrix-inversion-manual.jl
+++ b/docs/src/examples/matrix-inversion-manual.jl
@@ -143,8 +143,10 @@ MOI.set(
     model,
     DiffOpt.ForwardInConstraint(),
     cons[1],
-    0.0 * index(x[1]) - 1.0,
+    0.0 * index(x[1]) - 1.0,  # the tangent of the ConstraintFunction, i.e., ∂(Gx - h)/∂h = -1
 )
+
+# Note that `0.0 * index(x[1])` is used to make its type `MOI.AbstractScalarFunction`.
 
 # Compute derivatives
 
@@ -156,7 +158,7 @@ dx = MOI.get.(
     model,
     DiffOpt.ForwardOutVariablePrimal(),
     x,
-)
+)  # ∂x/∂h
 
 using Test                                  #src
 @test dx ≈ [0.25 ,0.75] atol=1e-4 rtol=1e-4 #src

--- a/docs/src/examples/matrix-inversion-manual.jl
+++ b/docs/src/examples/matrix-inversion-manual.jl
@@ -147,6 +147,7 @@ MOI.set(
 )
 
 # Note that `0.0 * index(x[1])` is used to make its type `typeof(0.0 * index(x[1]) - 1.0) <: MOI.AbstractScalarFunction`.
+# To indicate different direction to get directional derivative, users should replace `0.0 * index(x[1]) - 1.0` as the form of `dG*x - dh`, where `dG` and `dh` correspond to the elements of direction vectors along `G` and `h` axes, respectively.
 
 # Compute derivatives
 

--- a/docs/src/examples/matrix-inversion-manual.jl
+++ b/docs/src/examples/matrix-inversion-manual.jl
@@ -143,7 +143,7 @@ MOI.set(
     model,
     DiffOpt.ForwardInConstraint(),
     cons[1],
-    0.0 * index(x[1]) - 1.0,  # the tangent of the ConstraintFunction, i.e., ∂(Gx - h)/∂h = -1
+    0.0 * index(x[1]) - 1.0,  # to indicate the direction vector to get directional derivatives
 )
 
 # Note that `0.0 * index(x[1])` is used to make its type `typeof(0.0 * index(x[1]) - 1.0) <: MOI.AbstractScalarFunction`.

--- a/docs/src/examples/matrix-inversion-manual.jl
+++ b/docs/src/examples/matrix-inversion-manual.jl
@@ -44,8 +44,8 @@
 # ```math
 # \begin{gather}
 #  \begin{bmatrix} 
-#      Q & g^T \\
-#      \lambda^* g & g x^* - h
+#      Q & G^T \\
+#      \lambda^* G & G x^* - h
 #  \end{bmatrix}
 #  \begin{bmatrix} 
 #      dx \\

--- a/docs/src/examples/matrix-inversion-manual.jl
+++ b/docs/src/examples/matrix-inversion-manual.jl
@@ -146,7 +146,7 @@ MOI.set(
     0.0 * index(x[1]) - 1.0,  # the tangent of the ConstraintFunction, i.e., ∂(Gx - h)/∂h = -1
 )
 
-# Note that `0.0 * index(x[1])` is used to make its type `MOI.AbstractScalarFunction`.
+# Note that `0.0 * index(x[1])` is used to make its type `typeof(0.0 * index(x[1]) - 1.0) <: MOI.AbstractScalarFunction`.
 
 # Compute derivatives
 


### PR DESCRIPTION
I've followed some tutorials, and especially in comparison between manual QP differentiation and using DiffOpt,
I thought it would be better to add some explanation why `0.0 * index(x[1])` is used and what `-1.0` stands for `cause it's confusing considering the value of `h = -1.0`.