### PR TITLE
Fix conic objective reverse diff

### DIFF
--- a/src/ConicProgram/ConicProgram.jl
+++ b/src/ConicProgram/ConicProgram.jl
@@ -314,7 +314,7 @@ end
 function MOI.get(model::Model, ::DiffOpt.ReverseObjectiveFunction)
     g = model.back_grad_cache.g
     πz = model.back_grad_cache.πz
-    dc = DiffOpt.lazy_combination(-, πz, g, length(g))
+    dc = DiffOpt.lazy_combination(-, πz, g, length(g), eachindex(model.x))
     return DiffOpt.VectorScalarAffineFunction(dc, 0.0)
 end
 

--- a/src/diff_opt.jl
+++ b/src/diff_opt.jl
@@ -270,13 +270,13 @@ function lazy_combination(op::F, α, a, β, b) where {F<:Function}
     )
 end
 
-function lazy_combination(op::F, α, a, β, b, I::UnitRange) where {F<:Function}
+function lazy_combination(op::F, α, a, β, b, I::AbstractUnitRange) where {F<:Function}
     return lazy_combination(op, α, view(a, I), β, view(b, I))
 end
 function lazy_combination(op::F, a, b, i::Integer, args::Vararg{Any,N}) where {F<:Function,N}
     return lazy_combination(op, a[i], b, b[i], a, args...)
 end
-function lazy_combination(op::F, a, b, i::UnitRange, I::UnitRange) where {F<:Function}
+function lazy_combination(op::F, a, b, i::AbstractUnitRange, I::AbstractUnitRange) where {F<:Function}
     return lazy_combination(op, view(a, i), b, view(b, i), a, I)
 end
 
@@ -412,7 +412,7 @@ function _push_term(I::Vector, J::Vector, V::Vector, neg::Bool, r::Integer, term
     push!(J, term.variable.value)
     push!(V, neg ? -term.coefficient : term.coefficient)
 end
-function _push_term(I::Vector, J::Vector, V::Vector, neg::Bool, r::UnitRange, term::MOI.VectorAffineTerm)
+function _push_term(I::Vector, J::Vector, V::Vector, neg::Bool, r::AbstractUnitRange, term::MOI.VectorAffineTerm)
     _push_term(I, J, V, neg, r[term.output_index], term.scalar_term)
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -28,6 +28,7 @@ Check our results for QPs using the notations of [AK17].
 """
 function qp_test(
     solver,
+    diff_model,
     lt::Bool,
     set_zero::Bool,
     canonicalize::Bool;
@@ -79,6 +80,9 @@ function qp_test(
     atol = ATOL,
     rtol = RTOL,
 )
+    if !all(iszero, Q) && diff_model == DiffOpt.ConicProgram.Model
+        return # TODO https://github.com/jump-dev/DiffOpt.jl/pull/231
+    end
     n = length(q)
     @assert n == LinearAlgebra.checksquare(Q)
     @assert n == size(A, 2)
@@ -141,6 +145,8 @@ function qp_test(
         _λ = vcat(_λ, MOI.get.(model, MOI.ConstraintDual(), clb))
     end
     @_test(convert(Vector{Float64}, _λ), λ)
+
+    MOI.set(model, DiffOpt.ModelConstructor(), diff_model)
 
     #dobjb = v' * (dQb / 2.0) * v + dqb' * v
     # TODO, it should .-
@@ -271,7 +277,9 @@ function qp_test(solver; kws...)
     @testset "With $(lt ? "LessThan" : "GreaterThan") constraints" for lt in [true, false]
         @testset "With$(set_zero ? "" : "out") setting zero tangents" for set_zero in [true, false]
             @testset "With$(canonicalize ? "" : "out") canonicalization" for canonicalize in [true, false]
-                qp_test(solver, lt, set_zero, canonicalize; kws...)
+                @testset "With $diff_model" for diff_model in [DiffOpt.ConicProgram.Model, DiffOpt.QuadraticProgram.Model]
+                    qp_test(solver, diff_model, lt, set_zero, canonicalize; kws...)
+                end
             end
         end
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -273,13 +273,16 @@ function qp_test(
     @test pprod ≈ pprod atol = ATOL rtol = RTOL
 end
 
+function qp_test(solver, lt, set_zero, canonicalize; kws...)
+    @testset "With $diff_model" for diff_model in [DiffOpt.ConicProgram.Model, DiffOpt.QuadraticProgram.Model]
+        qp_test(solver, diff_model, lt, set_zero, canonicalize; kws...)
+    end
+end
+
 function qp_test(solver; kws...)
     @testset "With $(lt ? "LessThan" : "GreaterThan") constraints" for lt in [true, false]
         @testset "With$(set_zero ? "" : "out") setting zero tangents" for set_zero in [true, false]
             @testset "With$(canonicalize ? "" : "out") canonicalization" for canonicalize in [true, false]
-                @testset "With $diff_model" for diff_model in [DiffOpt.ConicProgram.Model, DiffOpt.QuadraticProgram.Model]
-                    qp_test(solver, diff_model, lt, set_zero, canonicalize; kws...)
-                end
             end
         end
     end


### PR DESCRIPTION
This PR throws the Conic diff through all the QP tests we have with no quadratic parts, this already caught one bug that is fixed in this PR