### PR TITLE
mention that exponential cone also works in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@
 This package has two major backends, available via the `reverse_differentiate!` and `forward_differentiate!` methods, to differentiate models (quadratic or conic) with optimal solutions.
 
 !!! note
-    Currently supports *linear programs* (LP), *convex quadratic programs* (QP) and *convex conic programs* (SDP, SOCP constraints only). 
+    Currently supports *linear programs* (LP), *convex quadratic programs* (QP) and *convex conic programs* (SDP, SOCP, exponential cone constraints only). 
 
 
 ## Installation


### PR DESCRIPTION
While most of the docs just refer to "conic programs", the note at the front specifically says only second-order and semidefinite programming is supported. this adds a small mention that the exponential cone is also supported.