### PR TITLE
Debug why there is a @test_broken

### DIFF
--- a/test/jump.jl
+++ b/test/jump.jl
@@ -465,7 +465,7 @@ function test_differentiating_simple_socp()
     db = zeros(5)
     dc = zeros(3)
     MOI.set.(model, DiffOpt.ReverseVariablePrimal(), vv, 1.0)
-    @test_broken DiffOpt.reverse_differentiate!(model)
+    DiffOpt.reverse_differentiate!(model)
     # TODO add tests
     return
 end


### PR DESCRIPTION
This seems to have stopped failing in https://github.com/jump-dev/DiffOpt.jl/pull/253 so let's see in the log what the error was