### PR TITLE
Implement dual of parameter anywhere

### DIFF
--- a/src/NonLinearProgram/nlp_utilities.jl
+++ b/src/NonLinearProgram/nlp_utilities.jl
@@ -27,6 +27,13 @@ function _fill_off_diagonal(H::SparseMatrixCSC)
     return ret
 end
 
+function _compute_gradient(model::Model)
+    evaluator = model.cache.evaluator
+    grad = zeros(length(model.x))
+    MOI.eval_objective_gradient(evaluator, grad, model.x)
+    return grad
+end
+
 """
     _compute_optimal_hessian(evaluator::MOI.Nonlinear.Evaluator, rows::Vector{JuMP.ConstraintRef}, x::Vector{JuMP.VariableRef})
 
@@ -104,7 +111,7 @@ function _create_evaluator(form::Form)
         backend,
         MOI.VariableIndex.(1:form.num_variables),
     )
-    MOI.initialize(evaluator, [:Hess, :Jac])
+    MOI.initialize(evaluator, [:Hess, :Jac, :Grad])
     return evaluator
 end
 
@@ -496,5 +503,10 @@ function _compute_sensitivity(model::Model; tol = 1e-6)
     ∂s[num_w+num_cons+1:num_w+num_cons+num_lower, :] *= _sense_multiplier
     # Dual bounds upper
     ∂s[num_w+num_cons+num_lower+1:end, :] *= -_sense_multiplier
-    return ∂s
+
+    # dual wrt parameter
+    primal_idx = [i.value for i in model.cache.primal_vars]
+    df_dx = _compute_gradient(model)[primal_idx]
+    df_dp = df_dx'∂s[1:num_vars, :]
+    return ∂s, df_dp
 end

--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -732,6 +732,26 @@ function MOI.get(
     )
 end
 
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.Parameter{T}},
+) where {T}
+    try
+        return MOI.get(
+            _checked_diff(model, attr, :forward_differentiate!),
+            attr,
+            model.index_map[ci],
+        )
+    catch
+        return MOI.get(
+            _checked_diff(model, attr, :reverse_differentiate!),
+            attr,
+            model.index_map[ci],
+        )
+    end
+end
+
 function MOI.supports(
     ::Optimizer,
     ::ReverseVariablePrimal,

--- a/test/nlp_program.jl
+++ b/test/nlp_program.jl
@@ -161,6 +161,8 @@ function test_analytical_simple(; P = 2) # Number of parameters
         # Compute derivatives
         DiffOpt.forward_differentiate!(m)
 
+        @test all(isapprox.(dual.(ParameterRef.(p)), dual.(con); atol = 1e-8))
+
         # Test sensitivities 
         @test_throws ErrorException MOI.get(
             m.moi_backend.optimizer.model.diff.model,
@@ -735,6 +737,8 @@ function test_ReverseConstraintDual()
 
     # Compute derivatives
     DiffOpt.reverse_differentiate!(m)
+
+    @test all(isapprox.(dual.(ParameterRef.(p)), dual.(con); atol = 1e-8))
 
     # Test sensitivities ReverseConstraintSet
     @test all(


### PR DESCRIPTION
It allows for the dual of parameters anywhere in the model.

```julia
using JuMP, DiffOpt, HiGHS

model = Model(() -> DiffOpt.diff_optimizer(Ipopt.Optimizer))
set_silent(model)

p_val = 4.0
pc_val = 2.0
@variable(model, x)
@variable(model, p in Parameter(p_val))
@variable(model, pc in Parameter(pc_val))
@constraint(model, cons, pc * x >= 3 * p)
@objective(model, Min, x^4)
optimize!(model)

direction_p = 3.0
MOI.set(model, DiffOpt.ForwardConstraintSet(), ParameterRef(p), Parameter(direction_p))
DiffOpt.forward_differentiate!(model)

dual(p) # works

dual(pc) # also works
```