### PR TITLE
Fix diff_optimizer with no bridge

### DIFF
--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -37,7 +37,7 @@ function diff_optimizer(
     add_poi =
         allow_parametric_opt_interface &&
         !MOI.supports_add_constrained_variable(
-            optimizer.model,
+            isnothing(with_bridge_type) ? optimizer : optimizer.model,
             MOI.Parameter{Float64},
         )
     # When we do `MOI.copy_to(diff, optimizer)` we need to efficiently `MOI.get`
@@ -48,7 +48,7 @@ function diff_optimizer(
     caching_opt = if with_outer_cache
         MOI.Utilities.CachingOptimizer(
             MOI.Utilities.UniversalFallback(
-                MOI.Utilities.Model{with_bridge_type}(),
+                MOI.Utilities.Model{something(with_bridge_type, Float64)}(),
             ),
             add_poi ? POI.Optimizer(optimizer) : optimizer,
         )

--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -48,7 +48,9 @@ function diff_optimizer(
     caching_opt = if with_outer_cache
         MOI.Utilities.CachingOptimizer(
             MOI.Utilities.UniversalFallback(
-                MOI.Utilities.Model{something(with_bridge_type, with_cache_type)}(),
+                MOI.Utilities.Model{
+                    something(with_bridge_type, with_cache_type)
+                }(),
             ),
             add_poi ? POI.Optimizer(optimizer) : optimizer,
         )

--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -49,7 +49,7 @@ function diff_optimizer(
         MOI.Utilities.CachingOptimizer(
             MOI.Utilities.UniversalFallback(
                 MOI.Utilities.Model{
-                    something(with_bridge_type, with_cache_type)
+                    something(with_bridge_type, with_cache_type),
                 }(),
             ),
             add_poi ? POI.Optimizer(optimizer) : optimizer,

--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -29,6 +29,9 @@ function diff_optimizer(
     with_outer_cache = true,
     allow_parametric_opt_interface = true,
 )
+    if isnothing(with_bridge_type) && !isnothing(with_cache_type)
+        with_outer_cache = false # Otherwise we'll have two caches in a row
+    end
     optimizer = MOI.instantiate(
         optimizer_constructor;
         with_bridge_type,
@@ -48,7 +51,7 @@ function diff_optimizer(
     caching_opt = if with_outer_cache
         MOI.Utilities.CachingOptimizer(
             MOI.Utilities.UniversalFallback(
-                MOI.Utilities.Model{something(with_bridge_type, Float64)}(),
+                MOI.Utilities.Model{with_bridge_type}(),
             ),
             add_poi ? POI.Optimizer(optimizer) : optimizer,
         )

--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -29,9 +29,6 @@ function diff_optimizer(
     with_outer_cache = true,
     allow_parametric_opt_interface = true,
 )
-    if isnothing(with_bridge_type) && !isnothing(with_cache_type)
-        with_outer_cache = false # Otherwise we'll have two caches in a row
-    end
     optimizer = MOI.instantiate(
         optimizer_constructor;
         with_bridge_type,
@@ -51,7 +48,7 @@ function diff_optimizer(
     caching_opt = if with_outer_cache
         MOI.Utilities.CachingOptimizer(
             MOI.Utilities.UniversalFallback(
-                MOI.Utilities.Model{with_bridge_type}(),
+                MOI.Utilities.Model{something(with_bridge_type, with_cache_type)}(),
             ),
             add_poi ? POI.Optimizer(optimizer) : optimizer,
         )

--- a/test/jump_wrapper.jl
+++ b/test/jump_wrapper.jl
@@ -46,10 +46,14 @@ function test_jump_api()
         ],
         ineq in [true, false],
         _min in [true, false],
-        flip in [true, false]
+        flip in [true, false],
+        with_bridge_type in [Float64, nothing]
+        if isnothing(with_bridge_type) && SOLVER === SCS.Optimizer
+            continue
+        end
 
-        @testset "$(MODEL) with: $(SOLVER), $(ineq ? "ineqs" : "eqs"), $(_min ? "Min" : "Max"), $(flip ? "geq" : "leq")" begin
-            model = MODEL(SOLVER)
+        @testset "$(MODEL) with: $(SOLVER), $(ineq ? "ineqs" : "eqs"), $(_min ? "Min" : "Max"), $(flip ? "geq" : "leq") bridge:$with_bridge_type" begin
+            model = MODEL(SOLVER; with_bridge_type)
             set_silent(model)
 
             p_val = 4.0

--- a/test/jump_wrapper.jl
+++ b/test/jump_wrapper.jl
@@ -48,6 +48,7 @@ function test_jump_api()
         _min in [true, false],
         flip in [true, false],
         with_bridge_type in [Float64, nothing]
+
         if isnothing(with_bridge_type) && SOLVER === SCS.Optimizer
             continue
         end


### PR DESCRIPTION
Weirdly enough, it works after the first commit but fails once I remove the outer cache.
I think this is because POI first adds a quadratic constraint and then modifies it. Apparently it's not complaining if you have two layers of caches ?