### PR TITLE
Prep for v0.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffOpt"
 uuid = "930fe3bc-9c6b-11ea-2d94-6184641e85e7"
 authors = ["Akshay Sharma", "Mathieu Besançon", "Joaquim Dias Garcia", "Benoît Legat", "Oscar Dowson", "Andrew Rosemberg"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"


### PR DESCRIPTION
I don't think we need a breaking change, unless https://github.com/jump-dev/DiffOpt.jl/pull/281 was breaking ? It doesn't seem so.