### PR TITLE
Remove bridge instead of test

### DIFF
--- a/src/moi_wrapper.jl
+++ b/src/moi_wrapper.jl
@@ -50,6 +50,19 @@ function diff_optimizer(
         with_bridge_type,
         with_cache_type,
     )
+    if !isnothing(with_bridge_type)
+        # removed because of the `ZerosBridge` issue:
+        # https://github.com/jump-dev/MathOptInterface.jl/issues/2861
+        # - zeros bridge does not support duals because it cumbersome
+        # - many bridges do not support get ConstraintFunction because it is cumbersome
+        # so there is no way out of this error for now.
+        # at the same time this is a modeling corner case tha could be avoided
+        # by the user.
+        MOI.Bridges.remove_bridge(
+            optimizer,
+            MOI.Bridges.Variable.ZerosBridge{with_bridge_type},
+        )
+    end
     if allow_parametric_opt_interface &&
        !MOI.supports_add_constrained_variable(
         isnothing(with_bridge_type) ? optimizer : optimizer.model,

--- a/test/moi_wrapper.jl
+++ b/test/moi_wrapper.jl
@@ -27,27 +27,10 @@ end
 
 function test_moi_test_runtests()
     model = DiffOpt.diff_optimizer(HiGHS.Optimizer)
-    # `Variable.ZerosBridge` makes dual needed by some tests fail.
-    # MOI.Bridges.remove_bridge(
-    #     model.optimizer.optimizer.optimizer,
-    #     MOI.Bridges.Variable.ZerosBridge{Float64},
-    # )
     MOI.set(model, MOI.Silent(), true)
     config =
         MOI.Test.Config(; atol = 1e-7, exclude = Any[MOI.compute_conflict!,])
-    MOI.Test.runtests(
-        model,
-        config;
-        exclude = Any[
-        # removed because of the `ZerosBridge` issue:
-        # https://github.com/jump-dev/MathOptInterface.jl/issues/2861
-        # - zeros bridge does not support duals because it cumbersome
-        # - many bridges do not support get ConstraintFunction because it is cumbersome
-        # so there is no way out of this error for now.
-        # at the same time this is a modeling corner case tha could be avoided
-        # by the user.
-            "test_conic_linear_VectorOfVariables_2"],
-    )
+    MOI.Test.runtests(model, config;)
     return
 end
 


### PR DESCRIPTION
If there is a follow-up to https://github.com/jump-dev/MathOptInterface.jl/pull/2863 removing the test we can remove this.
At the same time its does not seem bad to block Zeros bridge from start