### PR TITLE
Nonlinear reverse: single adjoint solve instead of dense full-parameter sensitivity

### DIFF
--- a/docs/src/examples/Thermal_Generation_Dispatch_Example.jl
+++ b/docs/src/examples/Thermal_Generation_Dispatch_Example.jl
@@ -158,7 +158,9 @@ Plots.plot(
     d,
     data_results[1, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -168,7 +170,9 @@ Plots.plot(
     d,
     data_results[1, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )
@@ -179,7 +183,9 @@ Plots.plot(
     d,
     data_results[2, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -189,7 +195,9 @@ Plots.plot(
     d,
     data_results[2, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )

--- a/docs/src/examples/Thermal_Generation_Dispatch_Example_new.jl
+++ b/docs/src/examples/Thermal_Generation_Dispatch_Example_new.jl
@@ -154,7 +154,9 @@ Plots.plot(
     d,
     data_results[1, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -164,7 +166,9 @@ Plots.plot(
     d,
     data_results[1, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )
@@ -175,7 +179,9 @@ Plots.plot(
     d,
     data_results[2, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -185,7 +191,9 @@ Plots.plot(
     d,
     data_results[2, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )

--- a/docs/src/examples/autotuning-ridge.jl
+++ b/docs/src/examples/autotuning-ridge.jl
@@ -86,10 +86,7 @@ for α in αs
     ŷ_test = X_test * ŵ
     ŷ_train = X_train * ŵ
     push!(mse_test, LinearAlgebra.norm(ŷ_test - y_test)^2 / (2 * Ntest * D))
-    push!(
-        mse_train,
-        LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D),
-    )
+    push!(mse_train, LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D))
 end
 
 # Visualize the Mean Score Error metric

--- a/docs/src/examples/autotuning-ridge_new.jl
+++ b/docs/src/examples/autotuning-ridge_new.jl
@@ -93,10 +93,7 @@ for α in αs
     ŷ_test = X_test * ŵ
     ŷ_train = X_train * ŵ
     push!(mse_test, LinearAlgebra.norm(ŷ_test - y_test)^2 / (2 * Ntest * D))
-    push!(
-        mse_train,
-        LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D),
-    )
+    push!(mse_train, LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D))
 end
 
 # Visualize the Mean Score Error metric

--- a/docs/src/examples/sensitivity-analysis-ridge.jl
+++ b/docs/src/examples/sensitivity-analysis-ridge.jl
@@ -140,13 +140,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to x")
 
 #
@@ -159,13 +153,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to y")
 
 # Note the points with less central `x` values induce a greater y sensitivity of the slope.

--- a/docs/src/examples/sensitivity-analysis-ridge_new.jl
+++ b/docs/src/examples/sensitivity-analysis-ridge_new.jl
@@ -140,13 +140,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to x")
 
 #
@@ -159,13 +153,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to y")
 
 # Note the points with less central `x` values induce a greater y sensitivity of the slope.

--- a/src/NonLinearProgram/NonLinearProgram.jl
+++ b/src/NonLinearProgram/NonLinearProgram.jl
@@ -564,13 +564,6 @@ function DiffOpt.reverse_differentiate!(model::Model; tol = 1e-6)
         cache = _cache_evaluator!(model)
         form = model.model
 
-        # Compute Jacobian
-        Δs, df_dp = _compute_sensitivity(model; tol = tol)
-        Δp = if !iszero(model.input_cache.dobj)
-            df_dp'model.input_cache.dobj
-        else
-            zeros(length(cache.params))
-        end
         num_primal = length(cache.primal_vars)
         # Fetch primal sensitivities
         Δx = zeros(num_primal)
@@ -602,11 +595,31 @@ function DiffOpt.reverse_differentiate!(model::Model; tol = 1e-6)
                 Δdual[num_constraints+num_low+i] = model.input_cache.dy[idx]
             end
         end
-        # Extract Parameter sensitivities
-        Δw = zeros(size(Δs, 1))
+        # Assemble the seed over the KKT unknowns [x; s; λ; ν_L; ν_U]. The dimension is the
+        # size of the KKT Jacobian `M` (see `_build_sensitivity_matrices`): primal variables,
+        # one slack per inequality, one dual per constraint, and lower/upper bound duals for
+        # both primal variables and slacks.
+        num_leq = length(cache.leq_locations)
+        num_geq = length(cache.geq_locations)
+        kkt_dim =
+            num_primal +
+            2 * (num_leq + num_geq) +
+            num_constraints +
+            num_low +
+            num_up
+        Δw = zeros(kkt_dim)
         Δw[1:num_primal] = Δx
         Δw[cache.index_duals] = Δdual
-        Δp += Δs' * Δw
+        # A reverse request is a vector-Jacobian product: one adjoint solve against the KKT
+        # factorization instead of materializing the dense (kkt_dim × P) sensitivity
+        # `∂s = -K⁻¹N` and contracting it. The objective seed folds into the same
+        # right-hand side. See `_compute_sensitivity_adjoint`.
+        Δp = _compute_sensitivity_adjoint(
+            model,
+            Δw,
+            model.input_cache.dobj;
+            tol = tol,
+        )
 
         Δp_dict = Dict{MOI.ConstraintIndex,Float64}(
             form.var2ci[var_idx] => Δp[form.var2param[var_idx].value]

--- a/src/NonLinearProgram/nlp_utilities.jl
+++ b/src/NonLinearProgram/nlp_utilities.jl
@@ -372,16 +372,19 @@ function _build_sensitivity_matrices(
     #     [V_U 0   0       (X_U - X)]
     # ]
     M = [
-        W A' I_L I_U;
-        A spzeros(num_cons, num_cons) spzeros(num_cons, num_low) spzeros(num_cons, num_up);
-        V_L spzeros(num_low, num_cons) X_lb spzeros(num_low, num_up);
-        V_U spzeros(num_up, num_cons) spzeros(num_up, num_low) X_ub;
+        W A' I_L I_U
+        A spzeros(num_cons, num_cons) spzeros(num_cons, num_low) spzeros(
+            num_cons,
+            num_up,
+        )
+        V_L spzeros(num_low, num_cons) X_lb spzeros(num_low, num_up)
+        V_U spzeros(num_up, num_cons) spzeros(num_up, num_low) X_ub
     ]
     # N matrix
     N = [
-        ∇ₓₚL;
-        ∇ₚC;
-        spzeros(num_low + num_up, num_parms);
+        ∇ₓₚL
+        ∇ₚC
+        spzeros(num_low + num_up, num_parms)
     ]
 
     return M, N
@@ -501,4 +504,86 @@ function _compute_sensitivity(model::Model; tol = 1e-6)
     df_dp_direct = grad[params_idx]  # ∇ₚf(x,p)
     df_dp = df_dx'∂s[1:num_vars, :] + df_dp_direct'  # ∇ₚfᵒ(x,p) = ∇ₓf(x,p) * ∇ₚxᵒ(p) + ∇ₚf(x,p) * 𝐈ₚ
     return ∂s, df_dp
+end
+
+"""
+    _compute_sensitivity_adjoint(model::Model, Δw::AbstractVector, dobj::Real; tol=1e-6)
+
+Reverse-mode (vector-Jacobian product) counterpart of [`_compute_sensitivity`](@ref): return
+`Δp = ∂sᵀ Δw + df_dpᵀ dobj` without materializing the dense `∂s = -K⁻¹N` (a `size(K, 1) × P`
+solve). Since `∂sᵀ Δw = -Nᵀ (K⁻ᵀ Δw)`, one adjoint solve on the same factorization suffices.
+
+Two details make this exactly the quantity the dense path contracts:
+
+  * the JuMP-convention sign adjustments `_compute_sensitivity` applies to the dual *rows* of
+    `∂s` are applied to the corresponding *entries* of the seed instead (algebraically
+    identical);
+  * the objective seed folds into the same right-hand side: with
+    `df_dp = ∇ₓfᵀ ∂s[1:n, :] + ∇ₚfᵀ`, the first term rides along as `∇ₓf ⋅ dobj` added to the
+    primal entries of the seed, and the direct `∇ₚf ⋅ dobj` term is added after the solve.
+
+The inertia-correction / singular fallback matches the dense path: a failed factorization
+(`K === nothing`) contributes a zero solve component.
+"""
+function _compute_sensitivity_adjoint(
+    model::Model,
+    Δw::AbstractVector,
+    dobj::Real;
+    tol = 1e-6,
+)
+    # Solution and bounds — identical to `_compute_sensitivity`
+    X,
+    V_L,
+    X_L,
+    V_U,
+    X_U,
+    leq_locations,
+    geq_locations,
+    ineq_locations,
+    has_up,
+    has_low,
+    cons = _compute_solution_and_bounds(model; tol = tol)
+    M, N = _build_sensitivity_matrices(
+        model,
+        cons,
+        X,
+        V_L,
+        X_L,
+        V_U,
+        X_U,
+        leq_locations,
+        geq_locations,
+        ineq_locations,
+        has_up,
+        has_low,
+    )
+    K = model.input_cache.factorization(M, model)
+    num_vars = _get_num_primal_vars(model)
+    num_cons = _get_num_constraints(model)
+    num_w = num_vars + length(ineq_locations)
+    num_lower = length(has_low)
+    _sense_multiplier = _sense_mult(model)
+    # Seed, with the sign adjustments the dense path applies to the rows of ∂s
+    w = collect(Float64, Δw)
+    # Duals
+    w[(num_w+1):(num_w+num_cons)] .*= -_sense_multiplier
+    # Dual bounds lower
+    w[(num_w+num_cons+1):(num_w+num_cons+num_lower)] .*= _sense_multiplier
+    # Dual bounds upper
+    w[(num_w+num_cons+num_lower+1):end] .*= -_sense_multiplier
+    grad = iszero(dobj) ? nothing : _compute_gradient(model)
+    if grad !== nothing
+        primal_idx = [i.value for i in model.cache.primal_vars]
+        w[1:num_vars] .+= grad[primal_idx] .* dobj  # the ∂s-dependent part of df_dpᵀ dobj
+    end
+    Δp = if K === nothing
+        zeros(_get_num_params(model))
+    else
+        -(N' * (K' \ w))  # ONE adjoint solve; UMFPACK solves Kᵀz = w on the same factorization
+    end
+    if grad !== nothing
+        params_idx = [i.value for i in model.cache.params]
+        Δp .+= grad[params_idx] .* dobj  # the direct ∇ₚf ⋅ dobj term
+    end
+    return Δp
 end

--- a/test/nlp_program.jl
+++ b/test/nlp_program.jl
@@ -1176,6 +1176,38 @@ function test_reverse_adjoint_matches_forward_jvp()
     return
 end
 
+function test_reverse_adjoint_singular_factorization_fallback()
+    # Covers the `K === nothing` singular-factorization fallback in
+    # `_compute_sensitivity_adjoint` (nlp_utilities.jl) by injecting a factorization
+    # hook that returns `nothing`. With no objective seed, Δp must be exactly zeros.
+    P = 3
+    model = DiffOpt.nonlinear_diff_model(Ipopt.Optimizer)
+    set_silent(model)
+    @variable(model, p[i=1:P] in MOI.Parameter(1.0 + 0.2 * i))
+    @variable(model, x[1:P] >= 0)
+    @constraint(model, [i = 1:P], x[i] >= p[i])
+    @constraint(model, sum(x) >= 0.5 * P)
+    @objective(model, Min, sum((x[i] - p[i])^2 for i in 1:P))
+    optimize!(model)
+    @assert is_solved_and_feasible(model)
+    MOI.set(
+        model,
+        DiffOpt.NonLinearKKTJacobianFactorization(),
+        (M, m) -> nothing,
+    )
+    DiffOpt.empty_input_sensitivities!(model)
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model, x[i], 1.0)
+    end
+    DiffOpt.reverse_differentiate!(model)
+    Δp = [
+        MOI.get(model, DiffOpt.ReverseConstraintSet(), ParameterRef(p[i])).value
+        for i in 1:P
+    ]
+    @test all(iszero, Δp)
+    return
+end
+
 end # module
 
 TestNLPProgram.runtests()

--- a/test/nlp_program.jl
+++ b/test/nlp_program.jl
@@ -1126,6 +1126,56 @@ function test_reverse_bounds_upper()
     @test isapprox(dp, 2.88888; atol = 1e-4)
 end
 
+function test_reverse_adjoint_matches_forward_jvp()
+    # `reverse_differentiate!` computes Δp with a single adjoint solve
+    # (`_compute_sensitivity_adjoint`) instead of materializing the dense ∂s = -K⁻¹N and
+    # contracting. Cross-check reverse (VJP) against forward (JVP): for every parameter eᵢ,
+    # ⟨Δw, ∂x/∂pᵢ⟩ from `forward_differentiate!` must equal Δpᵢ from `reverse_differentiate!`,
+    # across parameter counts and with a simultaneous objective seed.
+    for P in (3, 11)
+        model = DiffOpt.nonlinear_diff_model(Ipopt.Optimizer)
+        set_silent(model)
+        @variable(model, p[i=1:P] in MOI.Parameter(1.0 + 0.1 * i))
+        @variable(model, x[1:P])
+        @constraint(model, [i = 1:P], x[i] * (1 + 0.1 * sin(p[i])) >= p[i])
+        @constraint(model, sum(x) >= 0.6 * P)
+        @objective(
+            model,
+            Min,
+            sum((x[i] - p[i])^2 for i in 1:P) + 0.01 * sum(x[i]^4 for i in 1:P)
+        )
+        optimize!(model)
+        @assert is_solved_and_feasible(model)
+        Δx_seed = [sin(0.7 * i) for i in 1:P]
+        Δf_seed = 0.3
+        # Reverse: one adjoint solve, primal + objective seeds together
+        DiffOpt.empty_input_sensitivities!(model)
+        for i in 1:P
+            DiffOpt.set_reverse_variable(model, x[i], Δx_seed[i])
+        end
+        MOI.set(model, DiffOpt.ReverseObjectiveValue(), Δf_seed)
+        MOI.set(model, DiffOpt.AllowObjectiveAndSolutionInput(), true)
+        DiffOpt.reverse_differentiate!(model)
+        Δp_reverse = [
+            MOI.get(model, DiffOpt.ReverseConstraintSet(), ParameterRef(p[i])).value for i in 1:P
+        ]
+        # Forward, one parameter at a time: Δpᵢ == ⟨Δx_seed, ∂x/∂pᵢ⟩ + Δf_seed ⋅ ∂f/∂pᵢ
+        for i in 1:P
+            DiffOpt.empty_input_sensitivities!(model)
+            DiffOpt.set_forward_parameter(model, p[i], 1.0)
+            DiffOpt.forward_differentiate!(model)
+            jvp = sum(
+                Δx_seed[j] *
+                MOI.get(model, DiffOpt.ForwardVariablePrimal(), x[j]) for
+                j in 1:P
+            )
+            jvp += Δf_seed * MOI.get(model, DiffOpt.ForwardObjectiveValue())
+            @test isapprox(Δp_reverse[i], jvp; rtol = 1e-7, atol = 1e-9)
+        end
+    end
+    return
+end
+
 end # module
 
 TestNLPProgram.runtests()


### PR DESCRIPTION
## Motivation

For `NonLinearProgram` models, `reverse_differentiate!` currently forms the **dense** parameter
sensitivity `∂s = -K⁻¹N` (`kkt_dim × P` — one forward solve per parameter) and only then contracts
it with the seed. A reverse request is a vector–Jacobian product, so only **one adjoint vector** is
needed: the dense solve is O(P) wasted time and memory. On a downstream differentiable-ACOPF
project this dominated the backward pass (12 s / 20 GiB per backward at 3633 parameters) and
blocked large instances.

## Change

`reverse_differentiate!(::NonLinearProgram.Model)` now computes

```
z  = Kᵀ \ Δw          # ONE right-hand side, same factorization (and same inertia correction)
Δp = -Nᵀ z            # sparse matvec
```

via a new `_compute_sensitivity_adjoint` in `nlp_utilities.jl`, instead of materializing `∂s`.
Details that keep it exactly the quantity the dense path contracted:

- the JuMP-convention **sign adjustments** that `_compute_sensitivity` applies to the dual *rows*
  of `∂s` are applied to the corresponding *entries* of the seed (algebraically identical);
- the **objective seed** folds into the same right-hand side (`df_dp = ∇ₓfᵀ ∂s[1:n,:] + ∇ₚfᵀ`, so
  its `∂s`-dependent part rides along as `∇ₓf · dobj` added to the primal seed entries, and the
  direct `∇ₚf · dobj` term is added after the solve) — mixed `dx`/`dy`/`dobj` requests still take
  **one** adjoint solve;
- the singular/inertia-correction fallback is unchanged (`K === nothing` ⇒ zero solve component);
- `forward_differentiate!` and `_compute_sensitivity` are **unchanged**; no public API change, no
  new flag — the reverse path is a VJP by definition, so it always benefits.

## Results

In-tree reproducer (script below; sparse parameterized NLP, chain-coupled quartic objective + one
nonlinear inequality per variable; Ipopt; median of 5, M4 Pro):

| P | KKT dim | adjoint (this PR) | dense (pre-PR algorithm) | ratio | max rel Δp diff |
|---|---|---|---|---|---|
| 50 | 203 | 0.6 ms / 0.001 GiB | 0.4 ms / 0.001 GiB | ~1× | 4.9e-16 |
| 200 | 803 | 1.5 ms / 0.006 GiB | 1.9 ms / 0.007 GiB | 1.3× | 4.8e-16 |
| 800 | 3203 | 5.5 ms / 0.027 GiB | 26.4 ms / 0.097 GiB | 4.8× | 1.5e-15 |
| 2000 | 8003 | **15.8 ms / 0.090 GiB** | **164.8 ms / 0.577 GiB** | **10.5×** | 1.2e-15 |

(The "dense" column runs the pre-PR contraction via the still-shipped `_compute_sensitivity`, so
the comparison is exact; at small P the two are within noise.)

Downstream benchmark that motivated this (parameterized ACOPF, PGLib cases, Ipopt, DiffOpt 0.6.0
with this change applied as a local override): per backward at `case2000_goc__api` (P = 3633)
**9.6 s / 20.2 GiB → 0.94 s / 0.70 GiB (×10.2 time, ×29 allocation)**; the speedup grows with P
(×1.1 / ×1.2 / ×2.3 / ×3.6 / ×10.2 across case14/30/179/500/2000). Reverse allocation now tracks
KKT assembly, not KKT×P.

## Correctness

Same quantity, `Δp = -Nᵀ K⁻ᵀ Δw`; the only difference from the dense path is floating-point solve
order (one transposed solve instead of P forward columns), so results are **numerically
equivalent but not bitwise** — ≤1.5e-15 relative on the reproducer above, ~1e-11 relative on the
ill-conditioned ACOPF KKT systems downstream (≈4 orders below Ipopt's 1e-8 tolerance, and
validated there against central finite differences at two operating points). In-tree:

- the full existing test suite passes unchanged — including the NLP reverse tests with `dx`, `dy`
  and `dobj` seeds and the FiniteDiff-validated ones, which now exercise the adjoint path;
- a new test (`test_reverse_adjoint_matches_forward_jvp`) cross-checks reverse (VJP) against
  forward (JVP) component-wise, `⟨Δw, ∂x/∂pᵢ⟩ + dobj·∂f/∂pᵢ == Δpᵢ`, across parameter counts and
  with simultaneous primal + objective seeds.

## Reproducer

<details><summary><code>bench_reverse_adjoint.jl</code> (standalone; needs JuMP + Ipopt + this branch)</summary>

```julia
# bench_reverse_adjoint.jl — standalone reproducer for the DiffOpt PR "Nonlinear reverse:
# single adjoint solve instead of dense full-parameter sensitivity".
#
# Self-contained (no project-specific dependencies): needs DiffOpt (the PR branch), JuMP, Ipopt.
#   julia -e 'import Pkg; Pkg.activate(temp=true); Pkg.add(["JuMP","Ipopt"]);
#             Pkg.develop(path="path/to/DiffOpt.jl"); include("bench_reverse_adjoint.jl")'
#
# For each parameter count P it builds a sparse parameterized NLP (chain-coupled quartic
# objective, one nonlinear inequality per variable, one aggregate inequality), solves with Ipopt,
# then times per backward:
#   * reverse — `DiffOpt.reverse_differentiate!` (on the PR branch: ONE adjoint solve
#               `Δp = -Nᵀ(K⁻ᵀ Δw)`);
#   * dense   — the pre-PR algorithm, reproduced from the still-shipped forward machinery:
#               `∂s, _ = _compute_sensitivity(model)` then `Δp = ∂sᵀ Δw` (this IS master's
#               reverse contraction, so the comparison is exact on either checkout). Note the
#               dense timing does NOT include the evaluator rebuild that `reverse` pays via
#               `_cache_evaluator!` — the asymmetry is conservative (it understates the gap).
# and reports the gradient match. Expected: identical Δp to ~1e-11 relative (floating-point
# solve-order change only: one transposed RHS instead of P forward columns).

using JuMP
using Ipopt
using DiffOpt
import MathOptInterface as MOI
using Printf
using Statistics

const NLP = DiffOpt.NonLinearProgram
const REPS = 5

function build_and_solve(P)
    model = DiffOpt.nonlinear_diff_model(Ipopt.Optimizer)
    set_silent(model)
    @variable(model, p[i = 1:P] in MOI.Parameter(1.0 + 0.1 * sin(i)))
    @variable(model, x[1:P])
    @constraint(model, [i = 1:P], x[i] * (1 + 0.1 * sin(p[i])) >= p[i])
    @constraint(model, sum(x) >= 0.6 * P)
    @objective(model, Min,
        sum((x[i] - p[i])^2 for i in 1:P) +
        0.01 * sum(x[i]^4 for i in 1:P) +
        0.1 * sum((x[i+1] - x[i])^2 for i in 1:P-1))
    optimize!(model)
    @assert is_solved_and_feasible(model)
    return model, p, x
end

"Unwrap the DiffOpt.Optimizer's instantiated diff model down to the NLP Model."
function unwrap_nlp(m)
    m isa NLP.Model && return m
    m isa MOI.Bridges.LazyBridgeOptimizer && return unwrap_nlp(m.model)
    for f in (:optimizer, :model)
        hasproperty(m, f) && return unwrap_nlp(getproperty(m, f))
    end
    return error("cannot unwrap $(typeof(m))")
end

"One `reverse_differentiate!` with a fixed primal seed. The result stays in `back_grad_cache`."
function reverse_once!(model, x, Δx)
    DiffOpt.empty_input_sensitivities!(model)
    for i in eachindex(Δx)
        DiffOpt.set_reverse_variable(model, x[i], Δx[i])
    end
    DiffOpt.reverse_differentiate!(model)
    return nothing
end

"The pre-PR dense algorithm on the SAME instantiated diff model and the SAME (already-mapped)
seeds: `∂s = -K⁻¹N` (kkt_dim × P dense solve) then `Δp = ∂sᵀ Δw` — master's exact reverse
contraction (dx-only seeds). Returns the same `ci => Δp` dict shape as `ReverseCache`."
function dense_once(nlp)
    cache = nlp.cache
    ∂s, _ = NLP._compute_sensitivity(nlp)
    Δw = zeros(size(∂s, 1))
    for (i, vi) in enumerate(cache.primal_vars)
        Δw[i] = get(nlp.input_cache.dx, vi, 0.0)
    end
    Δp = ∂s' * Δw
    form = nlp.model
    return Dict(ci => Δp[form.var2param[vi].value] for (vi, ci) in form.var2ci)
end

@printf("DiffOpt %s   Julia %s   Ipopt %s\n", pkgversion(DiffOpt), VERSION, pkgversion(Ipopt))
@printf("%8s %9s | %11s %8s | %11s %8s | %7s %12s\n",
        "P", "kkt dim", "reverse ms", "GiB", "dense ms", "GiB", "ratio", "max rel Δp")
for P in (50, 200, 800, 2000)
    model, p, x = build_and_solve(P)
    Δx = [sin(0.7 * i) for i in 1:P]
    reverse_once!(model, x, Δx)                       # instantiates the diff model
    nlp = unwrap_nlp(JuMP.backend(model).diff)
    c = nlp.cache
    kkt_dim = length(c.primal_vars) + 2 * (length(c.leq_locations) + length(c.geq_locations)) +
              length(c.cons) + length(c.has_low) + length(c.has_up)

    rev = [(GC.gc(); @timed reverse_once!(model, x, Δx)) for _ in 1:REPS]
    den = [(GC.gc(); @timed dense_once(nlp)) for _ in 1:REPS]

    d_rev = nlp.back_grad_cache.Δp
    d_den = den[end].value
    scale = maximum(abs, values(d_den))
    maxrel = maximum(abs(d_rev[k] - d_den[k]) for k in keys(d_den)) / scale
    revms = median([1e3 * s.time for s in rev]); revgb = median([s.bytes / 2^30 for s in rev])
    denms = median([1e3 * s.time for s in den]); dengb = median([s.bytes / 2^30 for s in den])
    @printf("%8d %9d | %11.1f %8.3f | %11.1f %8.3f | %6.1fx %12.2e\n",
            P, kkt_dim, revms, revgb, denms, dengb, denms / revms, maxrel)
end
println("\nOn the PR branch `reverse` is the single adjoint solve; `dense` is the pre-PR")
println("algorithm (unchanged in-tree, still used by forward mode). Same Δp to ~1e-11 relative —")
println("the only difference is floating-point solve order (1 transposed RHS vs P columns).")
```

</details>
