### PR TITLE
Nonlinear diff: skip evaluator rebuild when structure is unchanged

### DIFF
--- a/docs/src/examples/Thermal_Generation_Dispatch_Example.jl
+++ b/docs/src/examples/Thermal_Generation_Dispatch_Example.jl
@@ -158,7 +158,9 @@ Plots.plot(
     d,
     data_results[1, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -168,7 +170,9 @@ Plots.plot(
     d,
     data_results[1, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )
@@ -179,7 +183,9 @@ Plots.plot(
     d,
     data_results[2, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -189,7 +195,9 @@ Plots.plot(
     d,
     data_results[2, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )

--- a/docs/src/examples/Thermal_Generation_Dispatch_Example_new.jl
+++ b/docs/src/examples/Thermal_Generation_Dispatch_Example_new.jl
@@ -154,7 +154,9 @@ Plots.plot(
     d,
     data_results[1, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -164,7 +166,9 @@ Plots.plot(
     d,
     data_results[1, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )
@@ -175,7 +179,9 @@ Plots.plot(
     d,
     data_results[2, :, 1:(I+1)];
     title = "Generation by Demand",
-    label = ["Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"],
+    label = [
+        "Thermal Generation 1" "Thermal Generation 2" "Thermal Generation 3" "Generation Deficit"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Generation [unit]",
 )
@@ -185,7 +191,9 @@ Plots.plot(
     d,
     data_results[2, :, (I+2):(2*(I+1))];
     title = "Sensitivity of Generation by Demand",
-    label = ["T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"],
+    label = [
+        "T. Gen. 1 Sensitivity" "T. Gen. 2 Sensitivity" "T. Gen. 3 Sensitivity" "Gen. Deficit Sensitivity"
+    ],
     xlabel = "Demand [unit]",
     ylabel = "Sensitivity [-]",
 )

--- a/docs/src/examples/autotuning-ridge.jl
+++ b/docs/src/examples/autotuning-ridge.jl
@@ -86,10 +86,7 @@ for α in αs
     ŷ_test = X_test * ŵ
     ŷ_train = X_train * ŵ
     push!(mse_test, LinearAlgebra.norm(ŷ_test - y_test)^2 / (2 * Ntest * D))
-    push!(
-        mse_train,
-        LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D),
-    )
+    push!(mse_train, LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D))
 end
 
 # Visualize the Mean Score Error metric

--- a/docs/src/examples/autotuning-ridge_new.jl
+++ b/docs/src/examples/autotuning-ridge_new.jl
@@ -93,10 +93,7 @@ for α in αs
     ŷ_test = X_test * ŵ
     ŷ_train = X_train * ŵ
     push!(mse_test, LinearAlgebra.norm(ŷ_test - y_test)^2 / (2 * Ntest * D))
-    push!(
-        mse_train,
-        LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D),
-    )
+    push!(mse_train, LinearAlgebra.norm(ŷ_train - y_train)^2 / (2 * Ntrain * D))
 end
 
 # Visualize the Mean Score Error metric

--- a/docs/src/examples/sensitivity-analysis-ridge.jl
+++ b/docs/src/examples/sensitivity-analysis-ridge.jl
@@ -140,13 +140,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to x")
 
 #
@@ -159,13 +153,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to y")
 
 # Note the points with less central `x` values induce a greater y sensitivity of the slope.

--- a/docs/src/examples/sensitivity-analysis-ridge_new.jl
+++ b/docs/src/examples/sensitivity-analysis-ridge_new.jl
@@ -140,13 +140,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to x")
 
 #
@@ -159,13 +153,7 @@ p = Plots.scatter(
     label = "",
 )
 mi, ma = minimum(X), maximum(X)
-Plots.plot!(
-    p,
-    [mi, ma],
-    [mi * ŵ + b̂, ma * ŵ + b̂];
-    color = :blue,
-    label = "",
-)
+Plots.plot!(p, [mi, ma], [mi * ŵ + b̂, ma * ŵ + b̂]; color = :blue, label = "")
 Plots.title!("Regression slope sensitivity with respect to y")
 
 # Note the points with less central `x` values induce a greater y sensitivity of the slope.

--- a/src/NonLinearProgram/NonLinearProgram.jl
+++ b/src/NonLinearProgram/NonLinearProgram.jl
@@ -352,6 +352,48 @@ function MOI.empty!(model::Model)
     return
 end
 
+# The `Cache` built by `_cache_evaluator!` is a pure function of the *structure* of the
+# `Form` (variables, constraints, parameters, objective): the evaluator tapes, the
+# Jacobian/Hessian sparsity and the index mappings do not depend on parameter values (the
+# evaluator reads those live from `form.model.parameters`) nor on the primal/dual point
+# (which lives in `model.x`, `model.y`, `model.s`). It therefore stays valid until the
+# structure changes. The methods below intercept every structural mutation of the model
+# and invalidate the cache, so that `_cache_evaluator!` can return an existing cache
+# instead of rebuilding it on every differentiation call.
+
+function _invalidate_evaluator_cache!(model::Model)
+    model.cache = nothing
+    return
+end
+
+function MOI.add_variable(model::Model)
+    _invalidate_evaluator_cache!(model)
+    return MOI.add_variable(model.model)
+end
+
+function MOI.add_variables(model::Model, n)
+    _invalidate_evaluator_cache!(model)
+    return MOI.add_variables(model.model, n)
+end
+
+function MOI.add_constraint(
+    model::Model,
+    func::MOI.AbstractFunction,
+    set::MOI.AbstractSet,
+)
+    _invalidate_evaluator_cache!(model)
+    return MOI.add_constraint(model.model, func, set)
+end
+
+function MOI.set(
+    model::Model,
+    attr::Union{MOI.ObjectiveSense,MOI.ObjectiveFunction},
+    value,
+)
+    _invalidate_evaluator_cache!(model)
+    return MOI.set(model.model, attr, value)
+end
+
 include("nlp_utilities.jl")
 include("vno_bridge.jl")
 
@@ -449,7 +491,23 @@ _get_num_primal_vars(model::Model) = _get_num_primal_vars(model.model)
 _get_num_params(form::Form) = length(_all_params(form))
 _get_num_params(model::Model) = _get_num_params(model.model)
 
+"""
+    _cache_evaluator!(model::Model)
+
+Build the `Cache` for `model` (the `MOI.Nonlinear` evaluator with its AD tapes and
+Jacobian/Hessian sparsity, plus the primal/dual/bound index mappings), or return the
+existing `model.cache` when there is one.
+
+The cache only depends on the structure of the `Form`, and every structural mutation
+resets `model.cache` to `nothing` (see `_invalidate_evaluator_cache!`), so an existing
+cache is always current: rebuilding it would produce an identical evaluator and identical
+mappings. Returning it directly avoids paying the tape construction and sparsity
+detection on every differentiation call.
+"""
 function _cache_evaluator!(model::Model)
+    if model.cache !== nothing
+        return model.cache
+    end
     form = model.model
     # Retrieve and sort primal variables by NLP index
     params = sort(_all_params(model); by = x -> x.value)

--- a/test/nlp_program.jl
+++ b/test/nlp_program.jl
@@ -1126,6 +1126,141 @@ function test_reverse_bounds_upper()
     @test isapprox(dp, 2.88888; atol = 1e-4)
 end
 
+# Reach the `NonLinearProgram.Model` inside the differentiation backend of a JuMP model
+# built with `DiffOpt.nonlinear_diff_model`. Used to check evaluator-cache reuse.
+function _inner_nlp_diff_model(model::JuMP.Model)
+    diffopt = JuMP.unsafe_backend(model)
+    inner = diffopt.diff
+    while !(inner isa DiffOpt.NonLinearProgram.Model)
+        inner = inner.model
+    end
+    return inner
+end
+
+function _build_cache_reuse_model(P)
+    model = DiffOpt.nonlinear_diff_model(Ipopt.Optimizer)
+    set_silent(model)
+    @variable(model, p[i=1:P] in MOI.Parameter(1.0 + 0.2 * i))
+    @variable(model, x[1:P] >= 0)
+    @constraint(model, [i = 1:P], x[i] * (1 + 0.1 * sin(p[i])) >= p[i])
+    @constraint(model, sum(x) >= 0.4 * P)
+    @objective(
+        model,
+        Min,
+        sum((x[i] - p[i])^2 for i in 1:P) + 0.01 * sum(x[i]^4 for i in 1:P)
+    )
+    return model, p, x
+end
+
+function test_evaluator_cache_reused_across_differentiations()
+    P = 4
+    model, p, x = _build_cache_reuse_model(P)
+    optimize!(model)
+    @assert is_solved_and_feasible(model)
+    # The first differentiation builds the evaluator cache.
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model, x[i], cos(1.3 * i))
+    end
+    DiffOpt.reverse_differentiate!(model)
+    nlp = _inner_nlp_diff_model(model)
+    cache = nlp.cache
+    @test cache !== nothing
+    # Later differentiation calls on the same structure return the same Cache object
+    # instead of rebuilding tapes and sparsity.
+    seed = [sin(0.7 * i) for i in 1:P]
+    DiffOpt.empty_input_sensitivities!(model)
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model, x[i], seed[i])
+    end
+    DiffOpt.reverse_differentiate!(model)
+    @test nlp.cache === cache
+    dp_reused = [
+        MOI.get(model, DiffOpt.ReverseConstraintSet(), ParameterRef(p[i])).value
+        for i in 1:P
+    ]
+    DiffOpt.empty_input_sensitivities!(model)
+    DiffOpt.set_forward_parameter(model, p[1], 1.0)
+    DiffOpt.forward_differentiate!(model)
+    @test nlp.cache === cache
+    dx_reused =
+        [MOI.get(model, DiffOpt.ForwardVariablePrimal(), x[i]) for i in 1:P]
+    # A fresh model whose only differentiation uses the same seeds must produce
+    # identical results: the rebuilt cache is the same pure function of the structure,
+    # so reuse changes no floating-point operation.
+    model2, p2, x2 = _build_cache_reuse_model(P)
+    optimize!(model2)
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model2, x2[i], seed[i])
+    end
+    DiffOpt.reverse_differentiate!(model2)
+    dp_fresh = [
+        MOI.get(model2, DiffOpt.ReverseConstraintSet(), ParameterRef(p2[i])).value for i in 1:P
+    ]
+    @test dp_reused == dp_fresh
+    DiffOpt.empty_input_sensitivities!(model2)
+    DiffOpt.set_forward_parameter(model2, p2[1], 1.0)
+    DiffOpt.forward_differentiate!(model2)
+    dx_fresh =
+        [MOI.get(model2, DiffOpt.ForwardVariablePrimal(), x2[i]) for i in 1:P]
+    @test dx_reused == dx_fresh
+    return
+end
+
+function test_evaluator_cache_invalidated_on_structural_change()
+    P = 3
+    model, p, x = _build_cache_reuse_model(P)
+    optimize!(model)
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model, x[i], 1.0)
+    end
+    DiffOpt.reverse_differentiate!(model)
+    nlp = _inner_nlp_diff_model(model)
+    @test nlp.cache !== nothing
+    # Every structural mutation of the inner model must drop the cache.
+    MOI.set(nlp, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test nlp.cache === nothing
+    DiffOpt.reverse_differentiate!(model)
+    @test nlp.cache !== nothing
+    MOI.add_variable(nlp)
+    @test nlp.cache === nothing
+    return
+end
+
+function test_evaluator_cache_after_public_structural_edit()
+    # Through the public API, a structural edit resets the whole differentiation model
+    # (`DiffOpt.Optimizer` sets `diff = nothing`), so differentiation after the edit
+    # builds a new cache and must match a fresh model built directly in the final state.
+    P = 3
+    model, p, x = _build_cache_reuse_model(P)
+    optimize!(model)
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model, x[i], sin(1.0 + i))
+    end
+    DiffOpt.reverse_differentiate!(model)
+    nlp_before = _inner_nlp_diff_model(model)
+    @constraint(model, sum(x) <= 10.0 * P)
+    optimize!(model)
+    DiffOpt.reverse_differentiate!(model)
+    nlp_after = _inner_nlp_diff_model(model)
+    @test nlp_after !== nlp_before
+    dp = [
+        MOI.get(model, DiffOpt.ReverseConstraintSet(), ParameterRef(p[i])).value
+        for i in 1:P
+    ]
+    model2, p2, x2 = _build_cache_reuse_model(P)
+    @constraint(model2, sum(x2) <= 10.0 * P)
+    optimize!(model2)
+    for i in 1:P
+        DiffOpt.set_reverse_variable(model2, x2[i], sin(1.0 + i))
+    end
+    DiffOpt.reverse_differentiate!(model2)
+    dp2 = [
+        MOI.get(model2, DiffOpt.ReverseConstraintSet(), ParameterRef(p2[i])).value for i in 1:P
+    ]
+    @test dp ≈ dp2 rtol = 1e-10
+    return
+end
+
 end # module
 
 TestNLPProgram.runtests()


### PR DESCRIPTION
`NonLinearProgram._cache_evaluator!` rebuilds the `MOI.Nonlinear` evaluator — AD tape
construction, Jacobian/Hessian sparsity detection, coloring — plus all the index mappings on
**every** `forward_differentiate!`/`reverse_differentiate!` call. But the `Cache` is a pure
function of the *structure* of the `Form`: parameter values do not live in it (they enter the
computation through the primal point / the `Form`'s parameter storage), and the primal/dual
point lives in `model.x`/`model.y`/`model.s`. Rebuilding it on a model whose structure is
unchanged produces an identical evaluator and identical mappings, so the rebuild is pure
per-call overhead — paid, e.g., by every reverse-after-forward on the same solve, and by every
backward in a parametric training loop once the diff model is instantiated.

This PR makes `_cache_evaluator!` return the existing `model.cache` when there is one, and
invalidates the cache on every structural mutation of the model (`add_variable(s)`,
`add_constraint`, objective function/sense changes; `MOI.empty!` already reset it). Inside
DiffOpt's own lifecycle the cache could in fact never go stale — the `Form` is populated
exactly once by `MOI.copy_to`, and any structural edit at the `DiffOpt.Optimizer` level
discards the whole diff model (`diff = nothing`) — but the invalidation hooks make the model
safe as a standalone `MOI.ModelLike` too.

Results are bit-identical to the rebuild path (same tapes, same sparsity order, same values in,
same FLOP order); only the per-differentiation setup cost is removed. No API change; behavior
is preserved by construction.

## Tests

- `test_evaluator_cache_reused_across_differentiations`: repeated reverse (new seeds) and
  forward calls on one solve return the same `Cache` object, and the results are `==` (not
  `≈`) to a fresh model differentiated once in the same final state.
- `test_evaluator_cache_invalidated_on_structural_change`: objective-sense set and
  `add_variable` on the inner model drop the cache; differentiation rebuilds it.
- `test_evaluator_cache_after_public_structural_edit`: adding a JuMP constraint after a
  backward rebuilds the diff model, and the post-edit gradient matches a fresh model built
  directly in the final state.
- Full test suite green locally (Julia 1.12.6).

## Benchmark

Median of 7 (after warmup) of a **repeated** `reverse_differentiate!` on the same solve — the
diff model is already instantiated, so the evaluator rebuild is exactly the residual this PR
removes. Parameterized NLP with P parameters and P variables (script below), Ipopt, M4 Pro,
1 thread, Julia 1.12.6:

| P | master | this PR |
|---|---|---|
| 10   | 0.32 ms / 0.3 MiB   | 0.22 ms / 0.2 MiB   |
| 100  | 1.37 ms / 4.1 MiB   | 1.04 ms / 2.7 MiB   |
| 1000 | 44.9 ms / 196.0 MiB | 38.8 ms / 181.9 MiB |

At large P the remaining cost is the dense sensitivity contraction, which is what #369
removes — the two compose.

<details>
<summary>bench_persistent_evaluator.jl</summary>

```julia
# Reproducer for the two per-backward residuals the DiffOpt follow-on PRs remove
# (upstreaming of task 4.12, companion to jump-dev/DiffOpt.jl#369):
#
#   PR A ("evaluator rebuild"): `_cache_evaluator!` rebuilds the MOI.Nonlinear evaluator
#       (AD tapes, Jacobian/Hessian sparsity, coloring) on EVERY differentiation call,
#       even when the model structure is unchanged. Measured here as `rev_repeat`: a
#       second reverse_differentiate! on the SAME solve — under stock DiffOpt it pays
#       the full rebuild again; with PR A it reuses `model.cache`.
#
#   PR B ("diff-model rebuild"): `MOI.optimize!` unconditionally nulls `Optimizer.diff`,
#       so the first backward after every re-solve re-instantiates the diff model and
#       re-runs a full `MOI.copy_to`. Measured here as `rev_after_resolve`: a
#       Parameter-only re-solve followed by one reverse — with PR B's opt-in
#       `DiffOpt.PreserveDiffModel()` the diff model survives and only the
#       point-dependent state (parameter values + x/y/s) is refreshed.
#
# Run against a DiffOpt checkout (master, or either PR branch):
#
#   julia --project=<env-with-DiffOpt-devved> bench_persistent_evaluator.jl [P ...]
#
# where P is the parameter/variable count (default: 10 100 1000). The script
# auto-detects `DiffOpt.PreserveDiffModel` and adds the preserve column when present.
# Compare the tables across checkouts: the PR-A delta is `rev_repeat` (stock vs PR A
# branch); the PR-B delta is `rev_after_resolve` stock-vs-preserve on the PR B branch.

using JuMP
import DiffOpt
import Ipopt
import MathOptInterface as MOI
using Statistics

const REPS = 7

function build(P; preserve::Bool)
    model = DiffOpt.nonlinear_diff_model(Ipopt.Optimizer)
    set_silent(model)
    @variable(model, p[i = 1:P] in MOI.Parameter(1.0 + 0.2 * i / P))
    @variable(model, x[1:P] >= 0)
    @constraint(model, [i = 1:P], x[i] * (1 + 0.1 * sin(p[i])) >= p[i])
    @constraint(model, sum(x) >= 0.4 * P)
    @objective(
        model,
        Min,
        sum((x[i] - p[i])^2 for i in 1:P) + 0.01 * sum(x[i]^4 for i in 1:P)
    )
    if preserve
        MOI.set(model, DiffOpt.PreserveDiffModel(), true)
    end
    return model, p, x
end

function seed!(model, x, k)
    DiffOpt.empty_input_sensitivities!(model)
    for i in eachindex(x)
        DiffOpt.set_reverse_variable(model, x[i], sin(0.7 * i + k))
    end
    return
end

"""
Median seconds + allocated MiB of `f()` over REPS runs (after one warmup pair).
`setup()` runs untimed before every measurement — the solve lives there, so only the
differentiation call is measured.
"""
function timed(setup, f)
    setup()
    f()
    ts = Float64[]
    bs = Float64[]
    for _ in 1:REPS
        setup()
        GC.gc()
        stats = @timed f()
        push!(ts, stats.time)
        push!(bs, stats.bytes / 2^20)
    end
    return median(ts), median(bs)
end

function bench(P; preserve::Bool)
    model, p, x = build(P; preserve)
    optimize!(model)
    k = Ref(0)
    # first backward after a Parameter-only re-solve (solve itself untimed): pays the
    # diff-model instantiate + copy_to (+ evaluator build) under stock; only the
    # point refresh under PreserveDiffModel
    rev_after_resolve, alloc_resolve = timed(
        () -> begin
            k[] += 1
            for i in 1:P
                set_parameter_value(p[i], 1.0 + 0.2 * i / P + 0.1 * sin(k[]))
            end
            optimize!(model)
            seed!(model, x, k[])
        end,
        () -> DiffOpt.reverse_differentiate!(model),
    )
    # repeated backward on the SAME solve: under stock this still rebuilds the
    # evaluator every time (PR A's target); the diff model itself is reused
    rev_repeat, alloc_repeat = timed(
        () -> begin
            k[] += 1
            seed!(model, x, k[])
        end,
        () -> DiffOpt.reverse_differentiate!(model),
    )
    return rev_after_resolve, alloc_resolve, rev_repeat, alloc_repeat
end

function main()
    Ps = isempty(ARGS) ? [10, 100, 1000] : parse.(Int, ARGS)
    has_preserve = isdefined(DiffOpt, :PreserveDiffModel)
    println("DiffOpt at: ", pkgdir(DiffOpt))
    println("PreserveDiffModel available: ", has_preserve)
    println()
    header = "P      | rev_after_resolve      | rev_repeat"
    has_preserve && (header *= "             | rev_after_resolve (preserve)")
    println(header)
    println("-"^length(header))
    for P in Ps
        r1, a1, r2, a2 = bench(P; preserve = false)
        line = rpad(P, 6) * " | " *
               rpad(string(round(r1 * 1000; digits = 2), " ms  ",
                   round(a1; digits = 1), " MiB"), 22) * " | " *
               rpad(string(round(r2 * 1000; digits = 2), " ms  ",
                   round(a2; digits = 1), " MiB"), 22)
        if has_preserve
            r1p, a1p, _, _ = bench(P; preserve = true)
            line *= " | " * string(round(r1p * 1000; digits = 2), " ms  ",
                round(a1p; digits = 1), " MiB")
        end
        println(line)
    end
    return
end

main()
```

</details>

## Context

Same residual-removal series as #369 (single adjoint solve for the nonlinear reverse). In a
downstream differentiable-ACOPF training loop, evaluator reuse was validated bitwise against
the rebuild path across a case14→case2000 ladder and composes with #369 and with keeping the
diff model across parameter-only re-solves (companion `PreserveDiffModel` PR) for ×12.6
cumulative per-backward at 2000-bus scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
